### PR TITLE
style: fundo branco e texto preto para botão de guias

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -176,6 +176,16 @@ a:hover {
     color: var(--branco);
 }
 
+#encontrarGuiasBtn {
+    background: var(--branco);
+    color: #000;
+}
+
+#encontrarGuiasBtn:hover {
+    background: var(--branco);
+    color: #000;
+}
+
 .btn-large {
     padding: var(--spacing-lg) var(--spacing-2xl);
     font-size: 1.125rem;


### PR DESCRIPTION
## Summary
- ajusta cor do botão "Encontrar Guias" para fundo branco e texto preto

## Testing
- `npm test` *(erro: package.json não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3c62184c832493cf44d810499b60