### PR TITLE
feat: add Next.js API routes and schemas

### DIFF
--- a/app/api/(auth)/login/route.ts
+++ b/app/api/(auth)/login/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/lib/prisma";
+import { signToken } from "@/lib/auth";
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  const { email, password } = data;
+  if (typeof email !== "string" || typeof password !== "string") {
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data" },
+      { status: 400 }
+    );
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
+    return NextResponse.json(
+      { code: "UNAUTHORIZED", message: "Invalid credentials" },
+      { status: 401 }
+    );
+  }
+
+  const token = signToken({ sub: user.id, role: user.role });
+  return NextResponse.json({ token, user });
+}

--- a/app/api/(auth)/signup/route.ts
+++ b/app/api/(auth)/signup/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/lib/prisma";
+import { signupSchema } from "@/lib/zodSchemas";
+import { signToken } from "@/lib/auth";
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  const parsed = signupSchema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+  }
+
+  const { name, email, password, role, cadastur } = parsed.data;
+  const exists = await prisma.user.findUnique({ where: { email } });
+  if (exists)
+    return NextResponse.json(
+      { code: "CONFLICT", message: "Email already in use" },
+      { status: 409 }
+    );
+
+  const user = await prisma.user.create({
+    data: { name, email, passwordHash: await bcrypt.hash(password, 10), role, cadastur },
+  });
+
+  const token = signToken({ sub: user.id, role: user.role });
+  return NextResponse.json({ token, user }, { status: 201 });
+}

--- a/app/api/bookings/[id]/route.ts
+++ b/app/api/bookings/[id]/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { bookingUpdateSchema } from "@/lib/zodSchemas";
+
+function canAccess(user: { sub: string; role: string }, booking: any) {
+  if (user.role === "ADMIN") return true;
+  if (user.role === "TREKKER" && booking.trekkerId === user.sub) return true;
+  if (user.role === "GUIDE" && booking.expedition.guideId === user.sub) return true;
+  return false;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const auth = requireAuth(req);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const booking = await prisma.booking.findUnique({
+    where: { id: params.id },
+    include: { expedition: { select: { guideId: true } } },
+  });
+  if (!booking)
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Booking not found" },
+      { status: 404 }
+    );
+  if (!canAccess(auth.user, booking))
+    return NextResponse.json(
+      { code: "FORBIDDEN", message: "Insufficient role" },
+      { status: 403 }
+    );
+  return NextResponse.json(booking);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const auth = requireAuth(req);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const existing = await prisma.booking.findUnique({
+    where: { id: params.id },
+    include: { expedition: { select: { guideId: true } } },
+  });
+  if (!existing)
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Booking not found" },
+      { status: 404 }
+    );
+  if (!canAccess(auth.user, existing))
+    return NextResponse.json(
+      { code: "FORBIDDEN", message: "Insufficient role" },
+      { status: 403 }
+    );
+  const data = await req.json();
+  const parsed = bookingUpdateSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+  const booking = await prisma.booking.update({
+    where: { id: params.id },
+    data: parsed.data,
+  });
+  return NextResponse.json(booking);
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const auth = requireAuth(req);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const booking = await prisma.booking.findUnique({
+    where: { id: params.id },
+    include: { expedition: { select: { guideId: true } } },
+  });
+  if (!booking)
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Booking not found" },
+      { status: 404 }
+    );
+  if (!canAccess(auth.user, booking))
+    return NextResponse.json(
+      { code: "FORBIDDEN", message: "Insufficient role" },
+      { status: 403 }
+    );
+  await prisma.booking.delete({ where: { id: params.id } });
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { bookingCreateSchema } from "@/lib/zodSchemas";
+
+export async function GET(req: NextRequest) {
+  const auth = requireAuth(req);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const { searchParams } = new URL(req.url);
+  const page = Number(searchParams.get("page") ?? 1);
+  const pageSize = Number(searchParams.get("pageSize") ?? 20);
+  const where: any = {
+    trekkerId: searchParams.get("trekkerId") || undefined,
+    expeditionId: searchParams.get("expeditionId") || undefined,
+    status: searchParams.get("status") || undefined,
+  };
+  if (auth.user.role === "TREKKER") {
+    where.trekkerId = auth.user.sub;
+  } else if (auth.user.role === "GUIDE") {
+    where.expedition = { guideId: auth.user.sub };
+  }
+  const [items, total] = await Promise.all([
+    prisma.booking.findMany({
+      where,
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.booking.count({ where }),
+  ]);
+  return NextResponse.json({ items, total, page, pageSize });
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireAuth(req, ["TREKKER", "ADMIN", "GUIDE"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+
+  const data = await req.json();
+  const parsed = bookingCreateSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+
+  const expedition = await prisma.expedition.findUnique({
+    where: { id: parsed.data.expeditionId },
+  });
+  if (!expedition)
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Expedition not found" },
+      { status: 404 }
+    );
+
+  const totalCents = expedition.pricePerPersonCents * parsed.data.headcount;
+
+  const current = await prisma.booking.aggregate({
+    _sum: { headcount: true },
+    where: {
+      expeditionId: expedition.id,
+      status: { in: ["PENDING", "CONFIRMED"] },
+    },
+  });
+  const occupied = current._sum.headcount ?? 0;
+  if (occupied + parsed.data.headcount > expedition.maxPeople) {
+    return NextResponse.json(
+      { code: "CAPACITY_EXCEEDED", message: "No seats available" },
+      { status: 409 }
+    );
+  }
+
+  const booking = await prisma.$transaction(async (tx) => {
+    const created = await tx.booking.create({
+      data: {
+        expeditionId: expedition.id,
+        trekkerId: auth.user.sub,
+        headcount: parsed.data.headcount,
+        totalCents,
+        status: "PENDING",
+        notes: parsed.data.notes,
+      },
+    });
+    await tx.expedition.update({
+      where: { id: expedition.id },
+      data: { bookedCount: { increment: parsed.data.headcount } },
+    });
+    return created;
+  });
+
+  return NextResponse.json(booking, { status: 201 });
+}

--- a/app/api/expeditions/[id]/route.ts
+++ b/app/api/expeditions/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { expeditionUpdateSchema } from "@/lib/zodSchemas";
+
+async function ensureGuideOwnership(expeditionId: string, user: { sub: string; role: string }) {
+  if (user.role !== "GUIDE") return true;
+  const expedition = await prisma.expedition.findUnique({ where: { id: expeditionId } });
+  return expedition && expedition.guideId === user.sub;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const expedition = await prisma.expedition.findUnique({ where: { id: params.id } });
+  if (!expedition)
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Expedition not found" },
+      { status: 404 }
+    );
+  return NextResponse.json(expedition);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const auth = requireAuth(req, ["GUIDE", "ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  if (!(await ensureGuideOwnership(params.id, auth.user)))
+    return NextResponse.json(
+      { code: "FORBIDDEN", message: "Insufficient role" },
+      { status: 403 }
+    );
+  const data = await req.json();
+  const parsed = expeditionUpdateSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+  try {
+    const expedition = await prisma.expedition.update({
+      where: { id: params.id },
+      data: parsed.data,
+    });
+    return NextResponse.json(expedition);
+  } catch {
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Expedition not found" },
+      { status: 404 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const auth = requireAuth(req, ["GUIDE", "ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  if (!(await ensureGuideOwnership(params.id, auth.user)))
+    return NextResponse.json(
+      { code: "FORBIDDEN", message: "Insufficient role" },
+      { status: 403 }
+    );
+  try {
+    await prisma.expedition.delete({ where: { id: params.id } });
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Expedition not found" },
+      { status: 404 }
+    );
+  }
+}

--- a/app/api/expeditions/route.ts
+++ b/app/api/expeditions/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { expeditionCreateSchema } from "@/lib/zodSchemas";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const page = Number(searchParams.get("page") ?? 1);
+  const pageSize = Number(searchParams.get("pageSize") ?? 20);
+
+  const where: any = {
+    trailId: searchParams.get("trailId") || undefined,
+    guideId: searchParams.get("guideId") || undefined,
+    status: searchParams.get("status") || undefined,
+    ...(searchParams.get("from") || searchParams.get("to")
+      ? {
+          startDate: {
+            gte: searchParams.get("from")
+              ? new Date(searchParams.get("from")!)
+              : undefined,
+            lte: searchParams.get("to")
+              ? new Date(searchParams.get("to")!)
+              : undefined,
+          },
+        }
+      : {}),
+  };
+
+  const [items, total] = await Promise.all([
+    prisma.expedition.findMany({
+      where,
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { startDate: "asc" },
+    }),
+    prisma.expedition.count({ where }),
+  ]);
+  return NextResponse.json({ items, total, page, pageSize });
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireAuth(req, ["GUIDE", "ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const data = await req.json();
+  const parsed = expeditionCreateSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+
+  const guideId =
+    auth.user.role === "GUIDE"
+      ? auth.user.sub
+      : (data.guideId ?? auth.user.sub);
+  const expedition = await prisma.expedition.create({
+    data: { ...parsed.data, guideId },
+  });
+  return NextResponse.json(expedition, { status: 201 });
+}

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { mediaCreateSchema } from "@/lib/zodSchemas";
+
+export async function POST(req: NextRequest) {
+  const auth = requireAuth(req, ["GUIDE", "ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const data = await req.json();
+  const parsed = mediaCreateSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+  const media = await prisma.media.create({ data: parsed.data });
+  return NextResponse.json(media, { status: 201 });
+}

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { reviewCreateSchema } from "@/lib/zodSchemas";
+
+export async function POST(req: NextRequest) {
+  const auth = requireAuth(req, ["TREKKER", "GUIDE", "ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const data = await req.json();
+  const parsed = reviewCreateSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+  const review = await prisma.review.create({
+    data: { ...parsed.data, authorId: auth.user.sub },
+  });
+  return NextResponse.json(review, { status: 201 });
+}

--- a/app/api/trails/[id]/route.ts
+++ b/app/api/trails/[id]/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { trailUpdateSchema } from "@/lib/zodSchemas";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const trail = await prisma.trail.findUnique({ where: { id: params.id } });
+  if (!trail)
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Trail not found" },
+      { status: 404 }
+    );
+  return NextResponse.json(trail);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const auth = requireAuth(req, ["ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const data = await req.json();
+  const parsed = trailUpdateSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+  try {
+    const trail = await prisma.trail.update({ where: { id: params.id }, data: parsed.data });
+    return NextResponse.json(trail);
+  } catch {
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Trail not found" },
+      { status: 404 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const auth = requireAuth(req, ["ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  try {
+    await prisma.trail.delete({ where: { id: params.id } });
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "Trail not found" },
+      { status: 404 }
+    );
+  }
+}

--- a/app/api/trails/route.ts
+++ b/app/api/trails/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { trailCreateSchema } from "@/lib/zodSchemas";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const page = Number(searchParams.get("page") ?? 1);
+  const pageSize = Number(searchParams.get("pageSize") ?? 20);
+  const where = {
+    state: searchParams.get("state") || undefined,
+    city: searchParams.get("city") || undefined,
+    name: searchParams.get("name")
+      ? { contains: searchParams.get("name")!, mode: "insensitive" }
+      : undefined,
+    difficulty: searchParams.get("difficulty") || undefined,
+  };
+  const [items, total] = await Promise.all([
+    prisma.trail.findMany({
+      where,
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.trail.count({ where }),
+  ]);
+  return NextResponse.json({ items, total, page, pageSize });
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireAuth(req, ["ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const data = await req.json();
+  const parsed = trailCreateSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+  const trail = await prisma.trail.create({ data: parsed.data });
+  return NextResponse.json(trail, { status: 201 });
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { userUpdateSchema } from "@/lib/zodSchemas";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const user = await prisma.user.findUnique({ where: { id: params.id } });
+  if (!user)
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "User not found" },
+      { status: 404 }
+    );
+  return NextResponse.json(user);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const auth = requireAuth(req);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  if (auth.user.role !== "ADMIN" && auth.user.sub !== params.id)
+    return NextResponse.json(
+      { code: "FORBIDDEN", message: "Insufficient role" },
+      { status: 403 }
+    );
+  const data = await req.json();
+  const parsed = userUpdateSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+  const { password, ...rest } = parsed.data;
+  try {
+    const user = await prisma.user.update({
+      where: { id: params.id },
+      data: { ...rest, ...(password ? { passwordHash: await bcrypt.hash(password, 10) } : {}) },
+    });
+    return NextResponse.json(user);
+  } catch {
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "User not found" },
+      { status: 404 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const auth = requireAuth(req, ["ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  try {
+    await prisma.user.delete({ where: { id: params.id } });
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json(
+      { code: "NOT_FOUND", message: "User not found" },
+      { status: 404 }
+    );
+  }
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { signupSchema } from "@/lib/zodSchemas";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const page = Number(searchParams.get("page") ?? 1);
+  const pageSize = Number(searchParams.get("pageSize") ?? 20);
+  const q = searchParams.get("q");
+  const where: any = {
+    role: searchParams.get("role") || undefined,
+    OR: q
+      ? [
+          { name: { contains: q, mode: "insensitive" } },
+          { email: { contains: q, mode: "insensitive" } },
+          { cadastur: { contains: q, mode: "insensitive" } },
+        ]
+      : undefined,
+  };
+  const [items, total] = await Promise.all([
+    prisma.user.findMany({
+      where,
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.user.count({ where }),
+  ]);
+  return NextResponse.json({ items, total, page, pageSize });
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireAuth(req, ["ADMIN"]);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+  const data = await req.json();
+  const parsed = signupSchema.safeParse(data);
+  if (!parsed.success)
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid data", details: parsed.error.errors },
+      { status: 400 }
+    );
+  const { name, email, password, role, cadastur } = parsed.data;
+  const exists = await prisma.user.findUnique({ where: { email } });
+  if (exists)
+    return NextResponse.json(
+      { code: "CONFLICT", message: "Email already in use" },
+      { status: 409 }
+    );
+  const user = await prisma.user.create({
+    data: { name, email, passwordHash: await bcrypt.hash(password, 10), role, cadastur },
+  });
+  return NextResponse.json(user, { status: 201 });
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,26 @@
+import jwt from "jsonwebtoken";
+import { NextRequest } from "next/server";
+
+const SECRET = process.env.JWT_SECRET!;
+
+export function signToken(payload: { sub: string; role: string }) {
+  return jwt.sign(payload, SECRET, { expiresIn: "7d" });
+}
+
+export function getUser(req: NextRequest) {
+  const auth = req.headers.get("authorization");
+  if (!auth?.startsWith("Bearer ")) return null;
+  const token = auth.slice(7);
+  try {
+    return jwt.verify(token, SECRET) as { sub: string; role: string };
+  } catch {
+    return null;
+  }
+}
+
+export function requireAuth(req: NextRequest, roles?: string[]) {
+  const user = getUser(req);
+  if (!user) return { ok: false, status: 401, body: { code: "UNAUTHENTICATED", message: "Login required" } };
+  if (roles && !roles.includes(user.role)) return { ok: false, status: 403, body: { code: "FORBIDDEN", message: "Insufficient role" } };
+  return { ok: true, user };
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+export const prisma = (globalThis as any).__prisma ?? new PrismaClient();
+if (process.env.NODE_ENV !== "production") (globalThis as any).__prisma = prisma;

--- a/lib/zodSchemas.ts
+++ b/lib/zodSchemas.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+export const signupSchema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+  password: z.string().min(8),
+  role: z.enum(["ADMIN","GUIDE","TREKKER"]).default("TREKKER"),
+  cadastur: z.string().optional(),
+});
+
+export const userUpdateSchema = signupSchema.extend({
+  password: z.string().min(8).optional(),
+  bio: z.string().optional(),
+  phone: z.string().optional(),
+}).partial();
+
+export const trailCreateSchema = z.object({
+  name: z.string().min(2),
+  state: z.string().min(2),
+  city: z.string().min(2),
+  regionOrPark: z.string().min(2),
+  distanceKm: z.number().positive(),
+  elevationGainM: z.number().int().nonnegative(),
+  difficulty: z.enum(["EASY","MODERATE","HARD","EXTREME"]).default("MODERATE"),
+  requiresGuide: z.boolean().default(false),
+  entryFeeCents: z.number().int().nonnegative().nullable().optional(),
+  waterPoints: z.number().int().nonnegative().optional(),
+  campingSpots: z.number().int().nonnegative().optional(),
+  description: z.string().optional(),
+});
+
+export const trailUpdateSchema = trailCreateSchema.partial();
+
+export const expeditionCreateSchema = z.object({
+  trailId: z.string().min(1),
+  startDate: z.string().datetime(),
+  endDate: z.string().datetime(),
+  pricePerPersonCents: z.number().int().positive(),
+  maxPeople: z.number().int().positive(),
+  description: z.string().optional(),
+  status: z.enum(["DRAFT","PUBLISHED","CANCELLED","FINISHED"]).default("DRAFT"),
+}).refine(v => new Date(v.endDate) > new Date(v.startDate), { message: "endDate must be after startDate" });
+
+export const expeditionUpdateSchema = expeditionCreateSchema
+  .partial()
+  .refine(
+    (v) =>
+      !v.startDate ||
+      !v.endDate ||
+      new Date(v.endDate) > new Date(v.startDate),
+    { message: "endDate must be after startDate" }
+  );
+
+export const bookingCreateSchema = z.object({
+  expeditionId: z.string(),
+  headcount: z.number().int().positive().default(1),
+  notes: z.string().optional()
+});
+
+export const bookingUpdateSchema = z.object({
+  status: z.enum(["PENDING","CONFIRMED","CANCELLED","REFUNDED"]).optional(),
+  notes: z.string().optional()
+});
+
+export const mediaCreateSchema = z.object({
+  url: z.string().url(),
+  type: z.enum(["image","video"]),
+  caption: z.string().optional(),
+  trailId: z.string().nullable().optional(),
+  expeditionId: z.string().nullable().optional(),
+});
+
+export const reviewCreateSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().optional(),
+  trailId: z.string().nullable().optional(),
+  expeditionId: z.string().nullable().optional(),
+}).refine(v => v.trailId || v.expeditionId, { message: "trailId or expeditionId required" });

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,1 @@
+export const config = { matcher: ["/api/:path*"] };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add prisma, auth, and zod helpers
- implement CRUD API routes for users, trails, expeditions and bookings
- support media and review creation endpoints

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb431fc7588324b09b0927d8f13fd9