### PR TITLE
feat: add trail cover flag and dynamic carousel

### DIFF
--- a/README_Codex.md
+++ b/README_Codex.md
@@ -1,0 +1,31 @@
+# Trekko Codex
+
+## Seeds
+
+Execute a migração e popular a base com as trilhas:
+
+```bash
+npx prisma migrate dev -n add_media_isCover
+npx ts-node scripts/seed_trails.ts
+```
+
+A execução cria ou atualiza trilhas e define uma mídia de capa (`isCover = true`) para cada uma.
+
+## Validação
+
+Para verificar, consulte o endpoint de trilhas:
+
+```bash
+curl http://localhost:3000/api/trails?page=1&pageSize=12
+```
+
+Cada item retornará `coverImageUrl` com a URL da capa.
+
+## Testes
+
+Um teste de integração verifica o retorno da capa:
+
+```bash
+npm test
+```
+

--- a/app/api/trails/route.ts
+++ b/app/api/trails/route.ts
@@ -21,10 +21,15 @@ export async function GET(req: NextRequest) {
       skip: (page - 1) * pageSize,
       take: pageSize,
       orderBy: { createdAt: "desc" },
+      include: { media: { where: { isCover: true }, take: 1 } },
     }),
     prisma.trail.count({ where }),
   ]);
-  return NextResponse.json({ items, total, page, pageSize });
+  const withCovers = items.map((t) => ({
+    ...t,
+    coverImageUrl: t.media?.[0]?.url ?? null,
+  }));
+  return NextResponse.json({ items: withCovers, total, page, pageSize });
 }
 
 export async function POST(req: NextRequest) {

--- a/homepage.js
+++ b/homepage.js
@@ -136,128 +136,9 @@ class TrekkoHomepage {
     }
 
     loadData() {
-        this.loadTrilhas();
         this.loadGuias();
         this.loadEstados();
         this.loadDepoimentos();
-    }
-
-    loadTrilhas() {
-        // Top 10 trilhas mais bem avaliadas, priorizando MG, SP, RJ, ES em caso de empate
-        this.trilhas = [
-            {
-                id: 1,
-                name: "Pico da Bandeira",
-                location: "Alto Caparaó, MG",
-                image: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop",
-                difficulty: "Difícil",
-                duration: "2 dias",
-                distance: "14 km",
-                rating: 4.9,
-                reviews: 247
-            },
-            {
-                id: 2,
-                name: "Pico dos Marins",
-                location: "Piquete, SP",
-                image: "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=400&h=300&fit=crop",
-                difficulty: "Difícil",
-                duration: "1 dia",
-                distance: "12 km",
-                rating: 4.8,
-                reviews: 156
-            },
-            {
-                id: 3,
-                name: "Pedra do Sino",
-                location: "Teresópolis, RJ",
-                image: "https://images.unsplash.com/photo-1464822759844-d150baec4ba5?w=400&h=300&fit=crop",
-                difficulty: "Moderada",
-                duration: "1 dia",
-                distance: "8 km",
-                rating: 4.8,
-                reviews: 189
-            },
-            {
-                id: 4,
-                name: "Pedra Azul",
-                location: "Domingos Martins, ES",
-                image: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop",
-                difficulty: "Moderada",
-                duration: "Meio dia",
-                distance: "6 km",
-                rating: 4.8,
-                reviews: 134
-            },
-            {
-                id: 5,
-                name: "Cachoeira do Tabuleiro",
-                location: "Conceição do Mato Dentro, MG",
-                image: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop",
-                difficulty: "Fácil",
-                duration: "Meio dia",
-                distance: "4 km",
-                rating: 4.7,
-                reviews: 203
-            },
-            {
-                id: 6,
-                name: "Serra do Cipó",
-                location: "Santana do Riacho, MG",
-                image: "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=400&h=300&fit=crop",
-                difficulty: "Moderada",
-                duration: "1 dia",
-                distance: "15 km",
-                rating: 4.7,
-                reviews: 167
-            },
-            {
-                id: 7,
-                name: "Pico das Agulhas Negras",
-                location: "Itatiaia, RJ",
-                image: "https://images.unsplash.com/photo-1464822759844-d150baec4ba5?w=400&h=300&fit=crop",
-                difficulty: "Difícil",
-                duration: "1 dia",
-                distance: "10 km",
-                rating: 4.7,
-                reviews: 178
-            },
-            {
-                id: 8,
-                name: "Pico do Itacolomi",
-                location: "Ouro Preto, MG",
-                image: "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=400&h=300&fit=crop",
-                difficulty: "Moderada",
-                duration: "Meio dia",
-                distance: "5 km",
-                rating: 4.6,
-                reviews: 145
-            },
-            {
-                id: 9,
-                name: "Pedra da Gávea",
-                location: "Rio de Janeiro, RJ",
-                image: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop",
-                difficulty: "Difícil",
-                duration: "1 dia",
-                distance: "6 km",
-                rating: 4.6,
-                reviews: 234
-            },
-            {
-                id: 10,
-                name: "Pico da Neblina",
-                location: "São Gabriel da Cachoeira, AM",
-                image: "https://images.unsplash.com/photo-1464822759844-d150baec4ba5?w=400&h=300&fit=crop",
-                difficulty: "Extrema",
-                duration: "7 dias",
-                distance: "50 km",
-                rating: 4.6,
-                reviews: 89
-            }
-        ];
-        
-        this.renderTrilhas();
     }
 
     loadGuias() {
@@ -381,43 +262,6 @@ class TrekkoHomepage {
         this.renderDepoimentos();
     }
 
-    renderTrilhas() {
-        const container = document.getElementById("trilhasCarousel");
-        if (!container) return;
-        
-        container.innerHTML = this.trilhas.map(trilha => `
-            <div class="trilha-card">
-                <img src="${trilha.image}" alt="${trilha.name}" onerror="this.src=\'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=320&h=200&fit=crop\'"/>
-                <div class="trilha-card-content">
-                    <h3 class="trilha-title">${trilha.name}</h3>
-                    <p class="trilha-location">
-                        <i class="fas fa-map-marker-alt"></i>
-                        ${trilha.location}
-                    </p>
-                    <div class="trilha-stats">
-                        <span class="trilha-stat">
-                            <i class="fas fa-chart-line"></i>
-                            ${trilha.difficulty}
-                        </span>
-                        <span class="trilha-stat">
-                            <i class="fas fa-clock"></i>
-                            ${trilha.duration}
-                        </span>
-                        <span class="trilha-stat">
-                            <i class="fas fa-route"></i>
-                            ${trilha.distance}
-                        </span>
-                    </div>
-                    <div class="trilha-rating">
-                        <div class="stars">
-                            ${this.generateStars(trilha.rating)}
-                        </div>
-                        <span>${trilha.rating} (${trilha.reviews} avaliações)</span>
-                    </div>
-                </div>
-            </div>
-        `).join("");
-    }
 
     renderGuias() {
         const container = document.getElementById("guiasGrid");
@@ -508,44 +352,12 @@ class TrekkoHomepage {
     }
 
     setupCarousels() {
-        const trilhasPrev = document.getElementById("trilhasPrev");
-        const trilhasNext = document.getElementById("trilhasNext");
-        
-        if (trilhasPrev && trilhasNext) {
-            trilhasPrev.addEventListener("click", () => this.prevTrilha());
-            trilhasNext.addEventListener("click", () => this.nextTrilha());
-        }
         
         setInterval(() => {
             this.nextDepoimento();
         }, 5000);
     }
 
-    prevTrilha() {
-        const container = document.getElementById("trilhasCarousel");
-        if (!container) return;
-        
-        this.currentTrilhaIndex = Math.max(0, this.currentTrilhaIndex - 1);
-        this.updateTrilhaCarousel();
-    }
-
-    nextTrilha() {
-        const container = document.getElementById("trilhasCarousel");
-        if (!container) return;
-        
-        const maxIndex = this.trilhas.length - 3; 
-        this.currentTrilhaIndex = Math.min(maxIndex, this.currentTrilhaIndex + 1);
-        this.updateTrilhaCarousel();
-    }
-
-    updateTrilhaCarousel() {
-        const container = document.getElementById("trilhasCarousel");
-        if (!container) return;
-        
-        const cardWidth = 320 + 24; 
-        const translateX = -this.currentTrilhaIndex * cardWidth;
-        container.style.transform = `translateX(${translateX}px)`;
-    }
 
     nextDepoimento() {
         this.currentDepoimentoIndex = (this.currentDepoimentoIndex + 1) % this.depoimentos.length;

--- a/index.html
+++ b/index.html
@@ -276,13 +276,11 @@
                 <div class="carousel-container" id="trilhasCarousel">
                     <!-- Trilhas serão carregadas dinamicamente -->
                 </div>
-                <button class="carousel-btn carousel-prev" id="trilhasPrev">
-                    <i class="fas fa-chevron-left"></i>
-                </button>
-                <button class="carousel-btn carousel-next" id="trilhasNext">
-                    <i class="fas fa-chevron-right"></i>
-                </button>
             </div>
+            <script type="module">
+                import { renderTrailsCarousel } from "/scripts/trails-carousel.js";
+                renderTrailsCarousel(document.getElementById("trilhasCarousel"));
+            </script>
             
             <div class="section-footer">
                 <a href="trilhas.html" class="btn btn-primary">

--- a/prisma/migrations/20240704120000_add_media_isCover/migration.sql
+++ b/prisma/migrations/20240704120000_add_media_isCover/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Media" ADD COLUMN "isCover" BOOLEAN NOT NULL DEFAULT false;
+CREATE INDEX "Media_trailId_isCover_idx" ON "Media"("trailId", "isCover");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,50 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum Difficulty {
+  EASY
+  MODERATE
+  HARD
+  EXTREME
+}
+
+model Trail {
+  id            String     @id @default(cuid())
+  name          String
+  state         String
+  city          String
+  regionOrPark  String?
+  distanceKm    Float?
+  elevationGainM Int?
+  difficulty    Difficulty
+  requiresGuide Boolean    @default(false)
+  createdAt     DateTime   @default(now())
+  media         Media[]    @relation("TrailMedia")
+}
+
+model Media {
+  id           String   @id @default(cuid())
+  url          String
+  type         String
+  caption      String?
+  isCover      Boolean  @default(false)
+  trailId      String?
+  expeditionId String?
+
+  trail        Trail?      @relation("TrailMedia", fields: [trailId], references: [id])
+  expedition   Expedition? @relation("ExpeditionMedia", fields: [expeditionId], references: [id])
+  createdAt    DateTime @default(now())
+
+  @@index([trailId, isCover])
+}
+
+model Expedition {
+  id    String @id @default(cuid())
+  media Media[] @relation("ExpeditionMedia")
+}

--- a/public/scripts/trails-carousel.js
+++ b/public/scripts/trails-carousel.js
@@ -1,0 +1,59 @@
+export async function renderTrailsCarousel(container) {
+  const res = await fetch(`/api/trails?page=1&pageSize=12`, { cache: "no-store" });
+  if (!res.ok) return;
+  const { items } = await res.json();
+
+  const fallback = (w = 320, h = 200) =>
+    `https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=${w}&h=${h}&fit=crop`;
+
+  container.innerHTML = items
+    .map(
+      (t) => `
+    <div class="trilha-card animate-fade-in-up">
+      <img src="${t.coverImageUrl || fallback(400,300)}"
+           alt="${t.name}"
+           onerror="this.src='${fallback(320,200)}'">
+      <div class="trilha-card-content">
+        <h3 class="trilha-title">${t.name}</h3>
+        <p class="trilha-location">
+          <i class="fas fa-map-marker-alt"></i>
+          ${t.city}, ${t.state}
+        </p>
+        <div class="trilha-stats">
+          <span class="trilha-stat">
+            <i class="fas fa-chart-line"></i>
+            ${mapDifficulty(t.difficulty)}
+          </span>
+          ${t.distanceKm ? `
+          <span class="trilha-stat">
+            <i class="fas fa-route"></i>
+            ${Number(t.distanceKm).toFixed(0)} km
+          </span>` : ``}
+        </div>
+        ${renderRating(t)}
+      </div>
+    </div>
+  `
+    )
+    .join("");
+}
+
+function mapDifficulty(d) {
+  const map = { EASY: "Fácil", MODERATE: "Moderada", HARD: "Difícil", EXTREME: "Extrema" };
+  return map[d] ?? "Moderada";
+}
+
+function renderRating(t) {
+  if (typeof t.avgRating !== "number" || typeof t.ratingCount !== "number") return "";
+  const full = Math.floor(t.avgRating);
+  const half = t.avgRating - full >= 0.5;
+  const stars =
+    Array.from({ length: full })
+      .map(() => '<i class="fas fa-star"></i>')
+      .join("") + (half ? '<i class="fas fa-star-half-alt"></i>' : "");
+  return `
+    <div class="trilha-rating">
+      <div class="stars">${stars}</div>
+      <span>${t.avgRating.toFixed(1)} (${t.ratingCount} avaliações)</span>
+    </div>`;
+}

--- a/scripts/seed_trails.ts
+++ b/scripts/seed_trails.ts
@@ -1,0 +1,168 @@
+import { prisma } from "@/lib/prisma";
+
+const SOURCE: Array<{
+  name: string;
+  city: string; state: string; regionOrPark: string;
+  difficultyPt: "Fácil" | "Moderada" | "Difícil" | "Extrema";
+  distanceKm: number;
+  coverUrl: string;
+}> = [
+  {
+    name: "Pico da Bandeira",
+    city: "Alto Caparaó",
+    state: "MG",
+    regionOrPark: "Parque Nacional do Caparaó",
+    difficultyPt: "Difícil",
+    distanceKm: 14,
+    coverUrl: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop",
+  },
+  {
+    name: "Pico dos Marins",
+    city: "Piquete",
+    state: "SP",
+    regionOrPark: "Serra da Mantiqueira",
+    difficultyPt: "Difícil",
+    distanceKm: 12,
+    coverUrl: "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=400&h=300&fit=crop",
+  },
+  {
+    name: "Pedra do Sino",
+    city: "Teresópolis",
+    state: "RJ",
+    regionOrPark: "Parque Nacional da Serra dos Órgãos",
+    difficultyPt: "Moderada",
+    distanceKm: 8,
+    coverUrl: "https://images.unsplash.com/photo-1464822759844-d150baec4ba5?w=400&h=300&fit=crop",
+  },
+  {
+    name: "Pedra Azul",
+    city: "Domingos Martins",
+    state: "ES",
+    regionOrPark: "Parque Estadual da Pedra Azul",
+    difficultyPt: "Moderada",
+    distanceKm: 6,
+    coverUrl: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop",
+  },
+  {
+    name: "Cachoeira do Tabuleiro",
+    city: "Conceição do Mato Dentro",
+    state: "MG",
+    regionOrPark: "Parque Estadual do Pico do Itambé",
+    difficultyPt: "Fácil",
+    distanceKm: 4,
+    coverUrl: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop",
+  },
+  {
+    name: "Serra do Cipó",
+    city: "Santana do Riacho",
+    state: "MG",
+    regionOrPark: "Parque Nacional da Serra do Cipó",
+    difficultyPt: "Moderada",
+    distanceKm: 15,
+    coverUrl: "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=400&h=300&fit=crop",
+  },
+  {
+    name: "Pico das Agulhas Negras",
+    city: "Itatiaia",
+    state: "RJ",
+    regionOrPark: "Parque Nacional de Itatiaia",
+    difficultyPt: "Difícil",
+    distanceKm: 10,
+    coverUrl: "https://images.unsplash.com/photo-1464822759844-d150baec4ba5?w=400&h=300&fit=crop",
+  },
+  {
+    name: "Pico do Itacolomi",
+    city: "Ouro Preto",
+    state: "MG",
+    regionOrPark: "Parque Estadual do Itacolomi",
+    difficultyPt: "Moderada",
+    distanceKm: 5,
+    coverUrl: "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=400&h=300&fit=crop",
+  },
+  {
+    name: "Pedra da Gávea",
+    city: "Rio de Janeiro",
+    state: "RJ",
+    regionOrPark: "Parque Nacional da Tijuca",
+    difficultyPt: "Difícil",
+    distanceKm: 6,
+    coverUrl: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop",
+  },
+  {
+    name: "Pico da Neblina",
+    city: "São Gabriel da Cachoeira",
+    state: "AM",
+    regionOrPark: "Parque Nacional do Pico da Neblina",
+    difficultyPt: "Extrema",
+    distanceKm: 50,
+    coverUrl: "https://images.unsplash.com/photo-1464822759844-d150baec4ba5?w=400&h=300&fit=crop",
+  }
+];
+
+function mapDifficulty(pt: string) {
+  const m: Record<string, string> = { "Fácil": "EASY", "Moderada": "MODERATE", "Difícil": "HARD", "Extrema": "EXTREME" };
+  return m[pt] ?? "MODERATE";
+}
+
+async function main() {
+  for (const t of SOURCE) {
+    const trail = await prisma.trail.upsert({
+      where: {
+        id:
+          (
+            await prisma.trail.findFirst({
+              where: { name: t.name, city: t.city, state: t.state },
+            })
+          )?.id ?? "___none___",
+      },
+      update: {
+        regionOrPark: t.regionOrPark,
+        difficulty: mapDifficulty(t.difficultyPt) as any,
+        distanceKm: t.distanceKm,
+      },
+      create: {
+        name: t.name,
+        state: t.state,
+        city: t.city,
+        regionOrPark: t.regionOrPark,
+        distanceKm: t.distanceKm,
+        elevationGainM: 0,
+        difficulty: mapDifficulty(t.difficultyPt) as any,
+        requiresGuide: false,
+      },
+    }).catch(async () => {
+      const existing = await prisma.trail.findFirst({
+        where: { name: t.name, city: t.city, state: t.state },
+      });
+      if (existing) return existing;
+      return prisma.trail.create({
+        data: {
+          name: t.name,
+          state: t.state,
+          city: t.city,
+          regionOrPark: t.regionOrPark,
+          distanceKm: t.distanceKm,
+          elevationGainM: 0,
+          difficulty: mapDifficulty(t.difficultyPt) as any,
+          requiresGuide: false,
+        },
+      });
+    });
+
+    await prisma.media.updateMany({
+      where: { trailId: trail.id, isCover: true },
+      data: { isCover: false },
+    });
+
+    await prisma.media.create({
+      data: { trailId: trail.id, url: t.coverUrl, type: "image", isCover: true },
+    });
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/tests/trails.test.ts
+++ b/tests/trails.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { NextRequest } from 'next/server';
+import { prisma } from '../lib/prisma';
+import { GET } from '../app/api/trails/route';
+
+// This test ensures that coverImageUrl is returned when a cover media exists.
+test('GET /api/trails includes coverImageUrl', async () => {
+  const trail = await prisma.trail.create({
+    data: {
+      name: 'Test Trail',
+      state: 'MG',
+      city: 'Test City',
+      regionOrPark: 'Test Region',
+      distanceKm: 1,
+      elevationGainM: 0,
+      difficulty: 'EASY',
+      requiresGuide: false,
+    },
+  });
+  await prisma.media.create({
+    data: {
+      trailId: trail.id,
+      url: 'https://example.com/cover.jpg',
+      type: 'image',
+      isCover: true,
+    },
+  });
+
+  const req = new NextRequest('http://localhost/api/trails?page=1&pageSize=10');
+  const res = await GET(req);
+  const json = await res.json();
+  assert.equal(json.items[0].coverImageUrl, 'https://example.com/cover.jpg');
+});


### PR DESCRIPTION
## Summary
- add `isCover` flag to media and expose coverImageUrl on trails API
- seed trails with cover images and script to render carousel dynamically
- document seeding workflow and add integration test

## Testing
- `npx prisma migrate dev -n add_media_isCover` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb457e7d788324a853e78bb8f954d0