### PR TITLE
feat: add expedition listing endpoint and seeds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DATABASE_URL=""
+APP_BASE_URL="http://localhost:3000"
+TZ="America/Sao_Paulo"
+MP_PUBLIC_KEY=""
+MP_ACCESS_TOKEN=""
+MP_WEBHOOK_SECRET=""

--- a/app/api/trails/[trailId]/expeditions/route.ts
+++ b/app/api/trails/[trailId]/expeditions/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { filterExpeditionsSchema } from "@/lib/zodSchemas";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { trailId: string } }
+) {
+  const { searchParams } = new URL(req.url);
+  const parsed = filterExpeditionsSchema.safeParse({
+    from: searchParams.get("from") ?? undefined,
+    to: searchParams.get("to") ?? undefined,
+    page: searchParams.get("page") ?? undefined,
+    pageSize: searchParams.get("pageSize") ?? undefined,
+  });
+  if (!parsed.success) {
+    return NextResponse.json(
+      { code: "VALIDATION_ERROR", message: "Invalid query", details: parsed.error.errors },
+      { status: 400 }
+    );
+  }
+  const { from, to, page, pageSize } = parsed.data;
+  const where: any = {
+    trailId: params.trailId,
+    status: "published",
+    endDate: { gte: new Date() },
+  };
+  if (from || to) {
+    where.startDate = {
+      ...(from ? { gte: new Date(from) } : {}),
+      ...(to ? { lte: new Date(to) } : {}),
+    };
+  }
+  const [items, total] = await Promise.all([
+    prisma.expedition.findMany({
+      where,
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { startDate: "asc" },
+      include: {
+        guide: { include: { user: true } },
+        participants: { where: { paymentStatus: "approved" }, select: { id: true } },
+      },
+    }),
+    prisma.expedition.count({ where }),
+  ]);
+  const result = items.map((e) => ({
+    ...e,
+    availableSpots: e.maxPeople - e.participants.length,
+  }));
+  return NextResponse.json({ items: result, total, page, pageSize });
+}

--- a/lib/zodSchemas.ts
+++ b/lib/zodSchemas.ts
@@ -76,3 +76,10 @@ export const reviewCreateSchema = z.object({
   trailId: z.string().nullable().optional(),
   expeditionId: z.string().nullable().optional(),
 }).refine(v => v.trailId || v.expeditionId, { message: "trailId or expeditionId required" });
+
+export const filterExpeditionsSchema = z.object({
+  from: z.string().optional(),
+  to: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(15).default(15),
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "trekko-website",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "db:migrate": "prisma migrate deploy",
+    "db:seed": "ts-node --esm prisma/seed.ts",
+    "test": "prisma generate && node --loader ts-node/esm --test tests/*.ts",
+    "test:e2e": "echo 'e2e tests placeholder'"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@prisma/client": "5.7.0",
+    "prisma": "5.7.0",
+    "next-intl": "3.0.0",
+    "next-seo": "5.5.0",
+    "zod": "3.22.2",
+    "react-hook-form": "7.45.1",
+    "lucide-react": "0.294.0"
+  },
+  "devDependencies": {
+    "typescript": "5.3.0",
+    "ts-node": "10.9.1",
+    "tailwindcss": "3.3.3",
+    "postcss": "8.4.23",
+    "autoprefixer": "10.4.14"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,12 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  trekker
+  guide
+  admin
+}
+
 enum Difficulty {
   EASY
   MODERATE
@@ -14,37 +20,96 @@ enum Difficulty {
   EXTREME
 }
 
+enum ExpeditionStatus {
+  draft
+  published
+  closed
+}
+
+enum PaymentStatus {
+  pending
+  approved
+  refunded
+  cancelled
+}
+
+model User {
+  id        String   @id @default(uuid())
+  name      String
+  email     String   @unique
+  avatarUrl String?
+  role      Role     @default(trekker)
+  guide     Guide?
+  participants ExpeditionParticipant[]
+}
+
+model Guide {
+  id         String  @id
+  cadastur   String
+  bio        String?
+  isVerified Boolean @default(false)
+  user       User    @relation(fields: [id], references: [id])
+  expeditions Expedition[]
+}
+
 model Trail {
-  id            String     @id @default(cuid())
+  id            String   @id @default(uuid())
   name          String
-  state         String
+  state         String   @db.Char(2)
   city          String
+  slug          String   @unique @default(cuid())
   regionOrPark  String?
   distanceKm    Float?
   elevationGainM Int?
   difficulty    Difficulty
-  requiresGuide Boolean    @default(false)
-  createdAt     DateTime   @default(now())
-  media         Media[]    @relation("TrailMedia")
+  createdAt     DateTime @default(now())
+  media         Media[]
+  expeditions   Expedition[]
+  @@index([state, city, name])
 }
 
 model Media {
-  id           String   @id @default(cuid())
+  id           String   @id @default(uuid())
   url          String
   type         String
   caption      String?
   isCover      Boolean  @default(false)
   trailId      String?
   expeditionId String?
-
-  trail        Trail?      @relation("TrailMedia", fields: [trailId], references: [id])
-  expedition   Expedition? @relation("ExpeditionMedia", fields: [expeditionId], references: [id])
+  trail        Trail?      @relation(fields: [trailId], references: [id])
+  expedition   Expedition? @relation(fields: [expeditionId], references: [id])
   createdAt    DateTime @default(now())
-
   @@index([trailId, isCover])
 }
 
 model Expedition {
-  id    String @id @default(cuid())
-  media Media[] @relation("ExpeditionMedia")
+  id          String   @id @default(uuid())
+  trailId     String
+  guideId     String
+  startDate   DateTime
+  endDate     DateTime
+  priceCents  Int
+  maxPeople   Int
+  description String
+  status      ExpeditionStatus @default(draft)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  trail       Trail    @relation(fields: [trailId], references: [id])
+  guide       Guide    @relation(fields: [guideId], references: [id])
+  media       Media[]
+  participants ExpeditionParticipant[]
+  @@index([trailId, startDate])
+}
+
+model ExpeditionParticipant {
+  id            String   @id @default(uuid())
+  expeditionId  String
+  userId        String
+  paymentStatus PaymentStatus @default(pending)
+  mpPreferenceId String?
+  mpPaymentId   String?
+  createdAt     DateTime @default(now())
+  expedition    Expedition @relation(fields: [expeditionId], references: [id])
+  user          User       @relation(fields: [userId], references: [id])
+  @@unique([expeditionId, userId])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,59 @@
+import { prisma } from "../lib/prisma";
+import { seedTrails } from "../scripts/seed_trails";
+
+async function main() {
+  await seedTrails();
+  // create example guide
+  const user = await prisma.user.upsert({
+    where: { email: "guide@example.com" },
+    update: {},
+    create: {
+      name: "Guia Exemplo",
+      email: "guide@example.com",
+      avatarUrl: null,
+      role: "guide",
+    },
+  });
+  await prisma.guide.upsert({
+    where: { id: user.id },
+    update: { isVerified: true },
+    create: {
+      id: user.id,
+      cadastur: "000000000",
+      bio: "Guia de exemplo",
+      isVerified: true,
+    },
+  });
+  const trail = await prisma.trail.findFirst();
+  if (trail) {
+    await prisma.expedition.createMany({
+      data: [
+        {
+          trailId: trail.id,
+          guideId: user.id,
+          startDate: new Date(),
+          endDate: new Date(Date.now() + 86400000),
+          priceCents: 10000,
+          maxPeople: 10,
+          description: "Expedição de exemplo",
+          status: "published",
+        },
+        {
+          trailId: trail.id,
+          guideId: user.id,
+          startDate: new Date(Date.now() + 86400000 * 7),
+          endDate: new Date(Date.now() + 86400000 * 8),
+          priceCents: 12000,
+          maxPeople: 8,
+          description: "Expedição rascunho",
+          status: "draft",
+        },
+      ],
+    });
+  }
+}
+
+main()
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/seed_trails.ts
+++ b/scripts/seed_trails.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@/lib/prisma";
+import { prisma } from "../lib/prisma";
 
 const SOURCE: Array<{
   name: string;
@@ -104,7 +104,7 @@ function mapDifficulty(pt: string) {
   return m[pt] ?? "MODERATE";
 }
 
-async function main() {
+export async function seedTrails() {
   for (const t of SOURCE) {
     const trail = await prisma.trail.upsert({
       where: {
@@ -160,7 +160,7 @@ async function main() {
   }
 }
 
-main()
+seedTrails()
   .then(() => process.exit(0))
   .catch((e) => {
     console.error(e);


### PR DESCRIPTION
## Summary
- add GET /api/trails/[trailId]/expeditions endpoint with filtering and available spot calculation
- seed trails and create sample guide/expeditions via prisma scripts
- add project scaffolding: package.json and environment example

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@prisma%2fclient)*
- `npm test` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4749901c8324a2b55aaab299777c