### PR TITLE
feat: render states grid from API

### DIFF
--- a/app/api/trails/states/route.ts
+++ b/app/api/trails/states/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+function ufToName(uf: string) {
+  const map: Record<string, string> = {
+    AC: "Acre",
+    AL: "Alagoas",
+    AP: "Amapá",
+    AM: "Amazonas",
+    BA: "Bahia",
+    CE: "Ceará",
+    DF: "Distrito Federal",
+    ES: "Espírito Santo",
+    GO: "Goiás",
+    MA: "Maranhão",
+    MT: "Mato Grosso",
+    MS: "Mato Grosso do Sul",
+    MG: "Minas Gerais",
+    PA: "Pará",
+    PB: "Paraíba",
+    PR: "Paraná",
+    PE: "Pernambuco",
+    PI: "Piauí",
+    RJ: "Rio de Janeiro",
+    RN: "Rio Grande do Norte",
+    RS: "Rio Grande do Sul",
+    RO: "Rondônia",
+    RR: "Roraima",
+    SC: "Santa Catarina",
+    SP: "São Paulo",
+    SE: "Sergipe",
+    TO: "Tocantins",
+  };
+  return map[uf] ?? uf;
+}
+
+export async function GET(_req: NextRequest) {
+  const grouped = await prisma.trail.groupBy({
+    by: ["state"],
+    _count: { _all: true },
+  });
+
+  const perState = await Promise.all(
+    grouped.map(async (g) => {
+      const first = await prisma.trail.findFirst({
+        where: { state: g.state },
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        include: { media: { where: { isCover: true }, take: 1 } },
+      });
+
+      return {
+        state: g.state,
+        stateName: ufToName(g.state),
+        count: g._count._all,
+        trailName: first?.name ?? null,
+        trailCity: first?.city ?? null,
+        trailSlug: first?.slug ?? null,
+        coverImageUrl: first?.media?.[0]?.url ?? null,
+      };
+    })
+  );
+
+  perState.sort((a, b) => a.stateName.localeCompare(b.stateName, "pt-BR"));
+
+  return NextResponse.json({ items: perState });
+}
+

--- a/homepage.js
+++ b/homepage.js
@@ -5,7 +5,6 @@ class TrekkoHomepage {
         this.currentDepoimentoIndex = 0;
         this.trilhas = [];
         this.guias = [];
-        this.estados = [];
         this.depoimentos = [];
         
         this.init();
@@ -137,7 +136,6 @@ class TrekkoHomepage {
 
     loadData() {
         this.loadGuias();
-        this.loadEstados();
         this.loadDepoimentos();
     }
 
@@ -186,49 +184,6 @@ class TrekkoHomepage {
         ];
         
         this.renderGuias();
-    }
-
-    loadEstados() {
-        this.estados = [
-            {
-                name: "Rio de Janeiro",
-                image: "images/estados/rio-janeiro.jpg",
-                trilhas: 45,
-                destaque: "Pedra da Gávea, Pão de Açúcar"
-            },
-            {
-                name: "Minas Gerais",
-                image: "images/estados/minas-gerais.jpg",
-                trilhas: 67,
-                destaque: "Pico da Bandeira, Serra do Cipó"
-            },
-            {
-                name: "São Paulo",
-                image: "images/estados/sao-paulo.jpg",
-                trilhas: 38,
-                destaque: "Pico dos Marins, Pedra Grande"
-            },
-            {
-                name: "Espírito Santo",
-                image: "images/estados/espirito-santo.jpg",
-                trilhas: 29,
-                destaque: "Pedra Azul, Forno Grande"
-            },
-            {
-                name: "Bahia",
-                image: "images/estados/bahia.jpg",
-                trilhas: 52,
-                destaque: "Chapada Diamantina, Morro do Pai Inácio"
-            },
-            {
-                name: "Santa Catarina",
-                image: "images/estados/santa-catarina.jpg",
-                trilhas: 41,
-                destaque: "Morro da Igreja, Pedra Furada"
-            }
-        ];
-        
-        this.renderEstados();
     }
 
     loadDepoimentos() {
@@ -284,22 +239,6 @@ class TrekkoHomepage {
                         ${this.generateStars(guia.rating)}
                     </div>
                     <span>${guia.rating} • ${guia.expeditions} expedições</span>
-                </div>
-            </div>
-        `).join("");
-    }
-
-    renderEstados() {
-        const container = document.getElementById("estadosGrid");
-        if (!container) return;
-        
-        container.innerHTML = this.estados.map(estado => `
-            <div class="estado-card">
-                <img src="${estado.image}" alt="${estado.name}" onerror="this.src=\'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=250&h=150&fit=crop\'"/>
-                <div class="estado-card-content">
-                    <h3 class="estado-name">${estado.name}</h3>
-                    <p class="estado-count">${estado.trilhas} trilhas disponíveis</p>
-                    <p class="estado-destaque">${estado.destaque}</p>
                 </div>
             </div>
         `).join("");

--- a/index.html
+++ b/index.html
@@ -459,6 +459,7 @@
 
     <!-- Scripts -->
     <script src="auth-enhanced.js"></script>
+    <script type="module" src="/scripts/states-grid.js"></script>
     <script src="homepage.js"></script>
 </body>
 </html>

--- a/public/scripts/states-grid.js
+++ b/public/scripts/states-grid.js
@@ -1,0 +1,45 @@
+const FALLBACK = (w = 250, h = 150) =>
+  `https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=${w}&h=${h}&fit=crop`;
+
+function formatCount(n) {
+  return `${n} trilha${n === 1 ? "" : "s"} disponível${n === 1 ? "" : "is"}`;
+}
+
+export async function renderStatesGrid(container) {
+  try {
+    const res = await fetch("/api/trails/states", { cache: "no-store" });
+    if (!res.ok) throw new Error("Falha ao buscar estados");
+    const { items } = await res.json();
+
+    container.innerHTML = items
+      .map((s) => {
+        const img = s.coverImageUrl || FALLBACK();
+        const destaque = s.trailName
+          ? `${s.trailName}${s.trailCity ? `, ${s.trailCity}` : ""}`
+          : "—";
+        const alt = s.stateName;
+        return `
+          <div class="estado-card animate-fade-in-up">
+            <img src="${img}" alt="${alt}"
+                 onerror="this.src='${FALLBACK()}'">
+            <div class="estado-card-content">
+              <h3 class="estado-name">${s.stateName}</h3>
+              <p class="estado-count">${formatCount(s.count)}</p>
+              <p class="estado-destaque">${destaque}</p>
+            </div>
+          </div>`;
+      })
+      .join("");
+  } catch (e) {
+    console.error(e);
+    container.innerHTML = `
+      <div class="estado-card">
+        <div class="estado-card-content">
+          <p>Não foi possível carregar os estados. Tente novamente.</p>
+        </div>
+      </div>`;
+  }
+}
+
+const mount = document.getElementById("estadosGrid");
+if (mount) renderStatesGrid(mount);

--- a/tests/trails-states.test.ts
+++ b/tests/trails-states.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { NextRequest } from 'next/server';
+import { prisma } from '../lib/prisma';
+import { GET } from '../app/api/trails/states/route';
+
+// This test ensures grouping by state and returning first trail info
+
+const commonTrail = {
+  city: 'Test City',
+  regionOrPark: 'Test Region',
+  distanceKm: 1,
+  elevationGainM: 0,
+  difficulty: 'EASY' as const,
+  requiresGuide: false,
+};
+
+test('GET /api/trails/states returns counts and first trail per state', async () => {
+  const mg = await prisma.trail.create({
+    data: {
+      name: 'MG Trail',
+      state: 'MG',
+      ...commonTrail,
+    },
+  });
+
+  const spEarly = await prisma.trail.create({
+    data: {
+      name: 'SP Early',
+      state: 'SP',
+      createdAt: new Date('2020-01-01'),
+      ...commonTrail,
+    },
+  });
+
+  await prisma.trail.create({
+    data: {
+      name: 'SP Late',
+      state: 'SP',
+      createdAt: new Date('2021-01-01'),
+      ...commonTrail,
+    },
+  });
+
+  await prisma.media.create({
+    data: {
+      trailId: spEarly.id,
+      url: 'https://example.com/cover.jpg',
+      type: 'image',
+      isCover: true,
+    },
+  });
+
+  const req = new NextRequest('http://localhost/api/trails/states');
+  const res = await GET(req);
+  const json = await res.json();
+
+  const mgState = json.items.find((i: any) => i.state === 'MG');
+  const spState = json.items.find((i: any) => i.state === 'SP');
+
+  assert.equal(mgState.count, 1);
+  assert.equal(mgState.trailName, 'MG Trail');
+  assert.equal(spState.count, 2);
+  assert.equal(spState.trailName, 'SP Early');
+  assert.equal(spState.coverImageUrl, 'https://example.com/cover.jpg');
+});


### PR DESCRIPTION
## Summary
- add endpoint to aggregate trails by state and include first trail cover
- dynamically render states grid from API data with fallback image
- drop hardcoded states from homepage script

## Testing
- `node --test tests/trails.test.ts tests/trails-states.test.ts` *(fails: Unknown file extension ".ts")*

------
https://chatgpt.com/codex/tasks/task_e_68bb49c7d4288324ad94fe575db141f2