### PR TITLE
Remove guides grid from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,9 +325,6 @@
                 </div>
             </div>
             
-            <div class="guias-grid" id="guiasGrid">
-            </div>
-            
             <div class="section-footer">
                 <a href="guias.html" class="btn btn-secondary">
                     <i class="fas fa-compass"></i>


### PR DESCRIPTION
## Summary
- remove guides grid container from homepage

## Testing
- `npm test` *(fails: prisma: not found)*
- `npm install` *(fails: 403 Forbidden for @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4da30d148324b6b5fc0ed428e081