### PR TITLE
style: destaca hero-subtitle com texto branco e negrito

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -413,6 +413,8 @@ a:hover {
 
 .hero-subtitle {
     font-size: clamp(1.125rem, 2.5vw, 1.375rem);
+    font-weight: 700;
+    color: var(--branco);
     margin-bottom: var(--spacing-2xl);
     opacity: 0.95;
     max-width: 700px;


### PR DESCRIPTION
## Summary
- torna o texto da hero subtitle branco e em negrito para melhor destaque

## Testing
- `npm test` *(erro: prisma not found)*
- `npm run lint` *(erro: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f03491883248dbabc2ae69b3e4e