### PR TITLE
fix: load trail images on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,6 +277,7 @@
                     <!-- Trilhas serão carregadas dinamicamente -->
                 </div>
             </div>
+            <script src="js/trail-images.js"></script>
             <script type="module">
                 import { renderTrailsCarousel } from "/scripts/trails-carousel.js";
                 renderTrailsCarousel(document.getElementById("trilhasCarousel"));

--- a/js/trail-images.js
+++ b/js/trail-images.js
@@ -264,7 +264,7 @@ if (!document.querySelector('#gallery-styles')) {
 // Função para obter imagem de capa da trilha
 function getTrailCoverImage(trailName) {
     const trailKey = normalizeTrailName(trailName);
-    return trailImages[trailKey]?.cover || 'images/trilhas/default-trail.jpg';
+    return trailImages[trailKey]?.cover || 'https://via.placeholder.com/400x300?text=Foto+indisponivel';
 }
 
 // Função para obter galeria de imagens da trilha

--- a/scripts/trails-carousel.js
+++ b/scripts/trails-carousel.js
@@ -46,7 +46,7 @@ function createTrailCard(trail) {
   const imageAlt = window.trailImages ? window.trailImages.getAlt(trail.name) : trail.name;
 
   card.innerHTML = `
-    <img src="${coverImage || 'images/placeholder-trail.jpg'}" alt="${imageAlt}">
+    <img src="${coverImage || 'https://via.placeholder.com/400x300?text=Foto+indisponivel'}" alt="${imageAlt}">
     <div class="trilha-card-content">
       <h3 class="trilha-title">${trail.name}</h3>
       <p class="trilha-location"><i class="fas fa-map-marker-alt"></i> ${trail.location || ''}${trail.state ? ', ' + trail.state : ''}</p>


### PR DESCRIPTION
## Summary
- load trail image mapping script on homepage carousel
- use remote placeholder image instead of local binary

## Testing
- `npm test` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb76e1d4f08324a4d933febd2111df