### PR TITLE
feat: adiciona carrossel de trilhas por estado

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,10 +348,15 @@
                     Trilhas incríveis em todos os estados brasileiros
                 </p>
             </div>
-            
-            <div class="estados-grid" id="estadosGrid">
-                <!-- Estados serão carregados dinamicamente -->
+            <div class="estados-carousel">
+                <div class="carousel-container" id="estadosCarousel">
+                    <!-- Estados serão carregados dinamicamente -->
+                </div>
             </div>
+            <script type="module">
+                import { renderStatesCarousel } from "/scripts/states-carousel.js";
+                renderStatesCarousel(document.getElementById("estadosCarousel"));
+            </script>
         </div>
     </section>
 
@@ -455,7 +460,6 @@
 
     <!-- Scripts -->
     <script src="auth-enhanced.js"></script>
-    <script type="module" src="/scripts/states-grid.js"></script>
     <script src="homepage.js"></script>
 </body>
 </html>

--- a/scripts/states-carousel.js
+++ b/scripts/states-carousel.js
@@ -1,0 +1,89 @@
+// Use relative path so the carousel works in any deployment environment
+const API_BASE_URL = '';
+const FALLBACK = (w = 400, h = 250) =>
+  `https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=${w}&h=${h}&fit=crop`;
+
+export async function renderStatesCarousel(container) {
+  if (!container) return;
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/trails/states`, {
+      cache: 'no-store',
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const items = data.items || [];
+    if (items.length === 0) {
+      container.innerHTML = '<p>Nenhum estado encontrado.</p>';
+      return;
+    }
+
+    items.forEach((state) => {
+      container.appendChild(createStateCard(state));
+    });
+
+    setupNavigation(container);
+  } catch (err) {
+    console.error('Erro ao carregar estados do carrossel:', err);
+    container.innerHTML = '<p>Erro ao carregar estados.</p>';
+  }
+}
+
+function createStateCard(state) {
+  const card = document.createElement('div');
+  card.className = 'estado-card';
+  const img = state.coverImageUrl || FALLBACK();
+  const alt = state.trailName || state.stateName;
+  card.innerHTML = `
+    <img src="${img}" alt="${alt}" onerror="this.src='${FALLBACK()}'">
+    <div class="estado-name-overlay">${state.stateName}</div>
+    <div class="estado-trilha-footer">${state.trailName || ''}</div>
+  `;
+  return card;
+}
+
+function setupNavigation(container) {
+  const wrapper = container.parentElement;
+  if (!wrapper) return;
+
+  const prevBtn = document.createElement('button');
+  prevBtn.className = 'carousel-btn carousel-prev';
+  prevBtn.innerHTML = '<i class="fas fa-chevron-left"></i>';
+
+  const nextBtn = document.createElement('button');
+  nextBtn.className = 'carousel-btn carousel-next';
+  nextBtn.innerHTML = '<i class="fas fa-chevron-right"></i>';
+
+  wrapper.appendChild(prevBtn);
+  wrapper.appendChild(nextBtn);
+
+  let currentIndex = 0;
+
+  function update() {
+    const card = container.querySelector('.estado-card');
+    if (!card) return;
+    const style = window.getComputedStyle(container);
+    const gap = parseInt(style.gap) || 0;
+    const cardWidth = card.offsetWidth + gap;
+    container.style.transform = `translateX(${-currentIndex * cardWidth}px)`;
+  }
+
+  prevBtn.addEventListener('click', () => {
+    if (currentIndex > 0) {
+      currentIndex--;
+      update();
+    }
+  });
+
+  nextBtn.addEventListener('click', () => {
+    if (currentIndex < container.children.length - 1) {
+      currentIndex++;
+      update();
+    }
+  });
+}
+
+export default { renderStatesCarousel };
+

--- a/styles.css
+++ b/styles.css
@@ -885,6 +885,43 @@ a:hover {
     margin-top: var(--spacing-xs);
 }
 
+.estados-carousel {
+    position: relative;
+    overflow: hidden;
+    margin-bottom: var(--spacing-2xl);
+}
+
+.estados-carousel .estado-card {
+    min-width: 300px;
+}
+
+.estados-carousel .estado-card img {
+    height: 200px;
+}
+
+.estado-name-overlay {
+    position: absolute;
+    top: var(--spacing-md);
+    left: var(--spacing-md);
+    background: rgba(0, 0, 0, 0.6);
+    color: var(--branco);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+}
+
+.estado-trilha-footer {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    color: var(--branco);
+    padding: var(--spacing-sm);
+    text-align: center;
+    font-size: 0.875rem;
+}
+
 /* Depoimentos Section */
 .depoimentos-carousel {
     position: relative;


### PR DESCRIPTION
## Summary
- add carousel for first trail in each state with image cover and trail name
- style state carousel with overlays and navigation controls
- fetch state trail data and enable prev/next navigation
- fix state carousel to use local API and avoid loading error

## Testing
- `npm test` *(fails: prisma: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb793f6d04832485ba883a1b5028de