### PR TITLE
Add missing Cadastur entry for guide authentication

### DIFF
--- a/auth-enhanced.js
+++ b/auth-enhanced.js
@@ -83,6 +83,13 @@ class TrekkoAuthManager {
                 estado: "AM",
                 especialidades: ["Floresta", "Ecoturismo"],
                 ativo: true
+            },
+            {
+                name: "Paulo Ricardo Gomes",
+                cadastur: "21467985879",
+                estado: "SP",
+                especialidades: ["Trilhas", "Montanha"],
+                ativo: true
             }
         ];
     }


### PR DESCRIPTION
## Summary
- include cadastur `21467985879` in the local guide validation dataset used by the authenticator

## Testing
- `npm test` *(fails: prisma not found)*
- `npm install` *(fails: 403 Forbidden fetching @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68bb825105288324b2c01429bb9677ac