### PR TITLE
fix: update guide dataset with correct cadastur info

### DIFF
--- a/auth-enhanced.js
+++ b/auth-enhanced.js
@@ -85,10 +85,14 @@ class TrekkoAuthManager {
                 ativo: true
             },
             {
-                name: "Paulo Ricardo Gomes",
+                name: "Julieli Ferrari dos Santos",
                 cadastur: "21467985879",
-                estado: "SP",
-                especialidades: ["Trilhas", "Montanha"],
+                estado: "RS",
+                especialidades: [
+                    "Ecoturismo",
+                    "Turismo Cultural",
+                    "Turismo de Negócios e Eventos"
+                ],
                 ativo: true
             }
         ];

--- a/auth.js
+++ b/auth.js
@@ -68,6 +68,16 @@ class AuthManager {
                 cadastur: "27741852963",
                 estado: "AM",
                 especialidades: ["Floresta", "Ecoturismo"]
+            },
+            {
+                name: "Julieli Ferrari dos Santos",
+                cadastur: "21467985879",
+                estado: "RS",
+                especialidades: [
+                    "Ecoturismo",
+                    "Turismo Cultural",
+                    "Turismo de Negócios e Eventos"
+                ]
             }
         ];
     }


### PR DESCRIPTION
## Summary
- correct CADASTUR dataset entry for Julieli Ferrari dos Santos
- sync legacy auth guide list with updated CADASTUR info

## Testing
- `npm test` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbda2cc00883249b260651ed0d58fb