### PR TITLE
Allow variable length CADASTUR in user registration

### DIFF
--- a/auth-enhanced.js
+++ b/auth-enhanced.js
@@ -521,8 +521,8 @@ class TrekkoAuthManager {
             return false;
         }
         
-        if (cadastur.length !== 11) {
-            this.showValidationMessage(cadasturValidation, 'CADASTUR deve ter exatamente 11 dígitos', 'error');
+        if (!/^\d+$/.test(cadastur)) {
+            this.showValidationMessage(cadasturValidation, 'CADASTUR deve conter apenas números', 'error');
             cadasturInput.classList.add('error');
             validationSummary.classList.add('hidden');
             return false;

--- a/new_auth.js
+++ b/new_auth.js
@@ -240,17 +240,14 @@ class TrekkoAuth {
         }
 
         const cleanCadastur = cadasturNumber.replace(/\D/g, '');
-        
-        if (cleanCadastur.length < 11) {
-            validationDiv.innerHTML = '<span class="trekko-validation-warning">⚠️ CADASTUR deve ter 11 dígitos</span>';
+
+        if (!cleanCadastur) {
+            validationDiv.innerHTML = '<span class="trekko-validation-error">❌ CADASTUR deve conter apenas números</span>';
             return false;
-        } else if (cleanCadastur.length > 11) {
-            validationDiv.innerHTML = '<span class="trekko-validation-error">❌ CADASTUR não pode ter mais de 11 dígitos</span>';
-            return false;
-        } else {
-            validationDiv.innerHTML = '<span class="trekko-validation-success">✅ Formato válido</span>';
-            return true;
         }
+
+        validationDiv.innerHTML = '<span class="trekko-validation-success">✅ Formato válido</span>';
+        return true;
     }
 
     async validateCadasturAPI(cadasturNumber) {

--- a/trekko_auth_backend/src/models/user.py
+++ b/trekko_auth_backend/src/models/user.py
@@ -62,14 +62,14 @@ class User(db.Model):
         
         # Remove non-digits
         clean_cadastur = ''.join(filter(str.isdigit, cadastur_number))
-        
-        if len(clean_cadastur) != 11:
-            return False, "CADASTUR deve ter exatamente 11 dígitos"
-        
-        # Basic validation - could be enhanced with real CADASTUR validation
-        if clean_cadastur == '00000000000' or clean_cadastur == '11111111111':
+
+        if not clean_cadastur:
             return False, "Número CADASTUR inválido"
-        
+
+        # Basic validation - could be enhanced with real CADASTUR validation
+        if len(set(clean_cadastur)) == 1:
+            return False, "Número CADASTUR inválido"
+
         return True, "CADASTUR válido"
     
     def __repr__(self):


### PR DESCRIPTION
## Summary
- remove hardcoded 11-digit CADASTUR check on the client
- relax backend CADASTUR validation to accept any numeric length

## Testing
- `npm test` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdc58edb88324888e6e0d4cc5be4f