### PR TITLE
Validate Cadastur against official dataset

### DIFF
--- a/trekko_auth_backend/src/models/guia_cadastur.py
+++ b/trekko_auth_backend/src/models/guia_cadastur.py
@@ -1,0 +1,16 @@
+from src.database import db
+
+class GuiaCadastur(db.Model):
+    """Model for the guias_cadastur table"""
+    __tablename__ = 'guias_cadastur'
+
+    id = db.Column(db.Integer, primary_key=True)
+    numero_do_certificado = db.Column('número_do_certificado', db.String(20), unique=True, nullable=False)
+    nome_completo = db.Column('nome_completo', db.Text)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'numero_do_certificado': self.numero_do_certificado,
+            'nome_completo': self.nome_completo,
+        }


### PR DESCRIPTION
## Summary
- add GuiaCadastur model to access official Cadastur records
- verify Cadastur numbers during registration and validation using official database

## Testing
- `npm test` *(fails: prisma: not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbdd3922e483248851de5873277705