### PR TITLE
Validate Cadastur against official dataset

### DIFF
--- a/auth-enhanced.js
+++ b/auth-enhanced.js
@@ -4,7 +4,7 @@
 class TrekkoAuthManager {
     constructor() {
         this.apiUrl = 'https://g8h3ilcvjnlq.manus.space/api';
-        this.guidesDatabase = this.loadGuidesDatabase();
+        // Base local de guias não é mais utilizada
         this.currentUser = null;
         this.authToken = null;
         
@@ -504,67 +504,58 @@ class TrekkoAuthManager {
     }
 
     // Validar CADASTUR em tempo real
-    validateCadastur() {
+    async validateCadastur() {
         const cadasturInput = document.getElementById('cadasturNumber');
         const cadasturValidation = document.getElementById('cadasturValidation');
-        const nameInput = document.getElementById('registerName');
         const validationSummary = document.getElementById('validationSummary');
-        const validationDetails = document.getElementById('validationDetails');
-        
+
         const cadastur = cadasturInput.value.trim();
-        const name = nameInput.value.trim();
-        
+
         if (!cadastur) {
             this.showValidationMessage(cadasturValidation, 'CADASTUR é obrigatório para guias', 'error');
             cadasturInput.classList.add('error');
             validationSummary.classList.add('hidden');
             return false;
         }
-        
+
         if (cadastur.length !== 11) {
             this.showValidationMessage(cadasturValidation, 'CADASTUR deve ter exatamente 11 dígitos', 'error');
             cadasturInput.classList.add('error');
             validationSummary.classList.add('hidden');
             return false;
         }
-        
-        // Verificar se o guia está na base de dados
-        const guide = this.findGuideInDatabase(name, cadastur);
-        
-        if (!guide) {
-            this.showValidationMessage(cadasturValidation, 'Nome e CADASTUR não encontrados na base de dados de guias certificados', 'error');
+
+        try {
+            const resp = await fetch(`${this.apiUrl}/auth/validate-cadastur`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ cadastur_number: cadastur })
+            });
+            const result = await resp.json();
+
+            if (!result.valid) {
+                this.showValidationMessage(cadasturValidation, result.message || 'CADASTUR inválido', 'error');
+                cadasturInput.classList.add('error');
+                validationSummary.classList.add('hidden');
+                return false;
+            }
+
+            this.showValidationMessage(cadasturValidation, 'CADASTUR válido e verificado', 'success');
+            cadasturInput.classList.remove('error');
+            cadasturInput.classList.add('success');
+            validationSummary.classList.add('hidden');
+            return true;
+        } catch (err) {
+            console.error('Erro ao validar CADASTUR:', err);
+            this.showValidationMessage(cadasturValidation, 'Erro ao validar CADASTUR', 'error');
             cadasturInput.classList.add('error');
             validationSummary.classList.add('hidden');
             return false;
         }
-        
-        // Guia encontrado - mostrar informações de validação
-        this.showValidationMessage(cadasturValidation, 'CADASTUR válido e verificado', 'success');
-        cadasturInput.classList.remove('error');
-        cadasturInput.classList.add('success');
-        
-        // Mostrar resumo da validação
-        validationDetails.innerHTML = `
-            <div class="guide-info">
-                <p><strong>Nome:</strong> ${guide.name}</p>
-                <p><strong>CADASTUR:</strong> ${guide.cadastur}</p>
-                <p><strong>Estado:</strong> ${guide.estado}</p>
-                <p><strong>Especialidades:</strong> ${guide.especialidades.join(', ')}</p>
-            </div>
-        `;
-        validationSummary.classList.remove('hidden');
-        
-        return true;
     }
 
-    // Encontrar guia na base de dados
-    findGuideInDatabase(name, cadastur) {
-        return this.guidesDatabase.find(guide => {
-            const nameMatch = this.normalizeString(guide.name) === this.normalizeString(name);
-            const cadasturMatch = guide.cadastur === cadastur;
-            return nameMatch && cadasturMatch && guide.ativo;
-        });
-    }
+    // (Descontinuado) Função de busca local de guias
+    // A validação agora é feita diretamente com o backend oficial
 
     // Normalizar string para comparação
     normalizeString(str) {
@@ -692,10 +683,20 @@ class TrekkoAuthManager {
                 return;
             }
 
-            // Verificar se o guia está na base de dados
-            const guide = this.findGuideInDatabase(name, cadastur);
-            if (!guide) {
-                this.showMessage(errorDiv, 'Nome e CADASTUR não encontrados na base de dados de guias certificados. Apenas guias registrados podem se cadastrar como profissionais.', 'error');
+            try {
+                const resp = await fetch(`${this.apiUrl}/auth/validate-cadastur`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ cadastur_number: cadastur })
+                });
+                const result = await resp.json();
+                if (!result.valid) {
+                    this.showMessage(errorDiv, result.message || 'CADASTUR inválido', 'error');
+                    return;
+                }
+            } catch (err) {
+                console.error('Erro ao validar CADASTUR:', err);
+                this.showMessage(errorDiv, 'Erro ao validar CADASTUR. Tente novamente.', 'error');
                 return;
             }
         }

--- a/trekko_auth_backend/src/models/guia_cadastur.py
+++ b/trekko_auth_backend/src/models/guia_cadastur.py
@@ -1,0 +1,16 @@
+from src.database import db
+
+class GuiaCadastur(db.Model):
+    """Model for the guias_cadastur table"""
+    __tablename__ = 'guias_cadastur'
+
+    id = db.Column(db.Integer, primary_key=True)
+    numero_do_certificado = db.Column('número_do_certificado', db.String(20), unique=True, nullable=False)
+    nome_completo = db.Column('nome_completo', db.Text)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'numero_do_certificado': self.numero_do_certificado,
+            'nome_completo': self.nome_completo,
+        }


### PR DESCRIPTION
## Summary
- verify CADASTUR numbers on the client by calling the backend validation endpoint
- submit `cadastur_number` to the API so guide registrations check the official dataset

## Testing
- `npm test` *(fails: prisma: not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbdd3922e483248851de5873277705