### PR TITLE
Validate Cadastur against official dataset

### DIFF
--- a/auth-enhanced.js
+++ b/auth-enhanced.js
@@ -4,7 +4,7 @@
 class TrekkoAuthManager {
     constructor() {
         this.apiUrl = 'https://g8h3ilcvjnlq.manus.space/api';
-        this.guidesDatabase = this.loadGuidesDatabase();
+        // Base local de guias não é mais utilizada
         this.currentUser = null;
         this.authToken = null;
         
@@ -142,11 +142,13 @@ class TrekkoAuthManager {
     // Configurar event listeners
     setupEventListeners() {
         console.log('Configurando event listeners de autenticação...');
-        
-        // Aguardar carregamento dos elementos
-        setTimeout(() => {
+
+        // Garantir que os botões existam antes de vincular eventos
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => this.bindAuthButtons());
+        } else {
             this.bindAuthButtons();
-        }, 100);
+        }
     }
 
     bindAuthButtons() {
@@ -355,8 +357,7 @@ class TrekkoAuthManager {
                                 Número CADASTUR *
                             </label>
                             <input type="text" id="cadasturNumber"
-                                   placeholder="Ex: 27123456789"
-                                   maxlength="11">
+                                   placeholder="Ex: 27123456789">
                             <div class="cadastur-info">
                                 <small>
                                     <i class="fas fa-info-circle"></i>
@@ -504,67 +505,62 @@ class TrekkoAuthManager {
     }
 
     // Validar CADASTUR em tempo real
-    validateCadastur() {
+    async validateCadastur() {
         const cadasturInput = document.getElementById('cadasturNumber');
         const cadasturValidation = document.getElementById('cadasturValidation');
-        const nameInput = document.getElementById('registerName');
         const validationSummary = document.getElementById('validationSummary');
-        const validationDetails = document.getElementById('validationDetails');
-        
+
         const cadastur = cadasturInput.value.trim();
-        const name = nameInput.value.trim();
-        
+
         if (!cadastur) {
             this.showValidationMessage(cadasturValidation, 'CADASTUR é obrigatório para guias', 'error');
             cadasturInput.classList.add('error');
             validationSummary.classList.add('hidden');
             return false;
         }
-        
-        if (cadastur.length !== 11) {
-            this.showValidationMessage(cadasturValidation, 'CADASTUR deve ter exatamente 11 dígitos', 'error');
+
+        if (!/^\d+$/.test(cadastur)) {
+            this.showValidationMessage(
+                cadasturValidation,
+                'CADASTUR deve conter apenas números',
+                'error'
+            );
             cadasturInput.classList.add('error');
             validationSummary.classList.add('hidden');
             return false;
         }
-        
-        // Verificar se o guia está na base de dados
-        const guide = this.findGuideInDatabase(name, cadastur);
-        
-        if (!guide) {
-            this.showValidationMessage(cadasturValidation, 'Nome e CADASTUR não encontrados na base de dados de guias certificados', 'error');
+
+        try {
+            const resp = await fetch(`${this.apiUrl}/auth/validate-cadastur`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ cadastur_number: cadastur })
+            });
+            const result = await resp.json();
+
+            if (!result.valid) {
+                this.showValidationMessage(cadasturValidation, result.message || 'CADASTUR inválido', 'error');
+                cadasturInput.classList.add('error');
+                validationSummary.classList.add('hidden');
+                return false;
+            }
+
+            this.showValidationMessage(cadasturValidation, 'CADASTUR válido e verificado', 'success');
+            cadasturInput.classList.remove('error');
+            cadasturInput.classList.add('success');
+            validationSummary.classList.add('hidden');
+            return true;
+        } catch (err) {
+            console.error('Erro ao validar CADASTUR:', err);
+            this.showValidationMessage(cadasturValidation, 'Erro ao validar CADASTUR', 'error');
             cadasturInput.classList.add('error');
             validationSummary.classList.add('hidden');
             return false;
         }
-        
-        // Guia encontrado - mostrar informações de validação
-        this.showValidationMessage(cadasturValidation, 'CADASTUR válido e verificado', 'success');
-        cadasturInput.classList.remove('error');
-        cadasturInput.classList.add('success');
-        
-        // Mostrar resumo da validação
-        validationDetails.innerHTML = `
-            <div class="guide-info">
-                <p><strong>Nome:</strong> ${guide.name}</p>
-                <p><strong>CADASTUR:</strong> ${guide.cadastur}</p>
-                <p><strong>Estado:</strong> ${guide.estado}</p>
-                <p><strong>Especialidades:</strong> ${guide.especialidades.join(', ')}</p>
-            </div>
-        `;
-        validationSummary.classList.remove('hidden');
-        
-        return true;
     }
 
-    // Encontrar guia na base de dados
-    findGuideInDatabase(name, cadastur) {
-        return this.guidesDatabase.find(guide => {
-            const nameMatch = this.normalizeString(guide.name) === this.normalizeString(name);
-            const cadasturMatch = guide.cadastur === cadastur;
-            return nameMatch && cadasturMatch && guide.ativo;
-        });
-    }
+    // (Descontinuado) Função de busca local de guias
+    // A validação agora é feita diretamente com o backend oficial
 
     // Normalizar string para comparação
     normalizeString(str) {
@@ -608,10 +604,7 @@ class TrekkoAuthManager {
 
     // Formatar CADASTUR (apenas números)
     formatCadastur(input) {
-        let value = input.value.replace(/\D/g, '');
-        if (value.length > 11) {
-            value = value.substring(0, 11);
-        }
+        const value = input.value.replace(/\D/g, '');
         input.value = value;
     }
 
@@ -692,10 +685,20 @@ class TrekkoAuthManager {
                 return;
             }
 
-            // Verificar se o guia está na base de dados
-            const guide = this.findGuideInDatabase(name, cadastur);
-            if (!guide) {
-                this.showMessage(errorDiv, 'Nome e CADASTUR não encontrados na base de dados de guias certificados. Apenas guias registrados podem se cadastrar como profissionais.', 'error');
+            try {
+                const resp = await fetch(`${this.apiUrl}/auth/validate-cadastur`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ cadastur_number: cadastur })
+                });
+                const result = await resp.json();
+                if (!result.valid) {
+                    this.showMessage(errorDiv, result.message || 'CADASTUR inválido', 'error');
+                    return;
+                }
+            } catch (err) {
+                console.error('Erro ao validar CADASTUR:', err);
+                this.showMessage(errorDiv, 'Erro ao validar CADASTUR. Tente novamente.', 'error');
                 return;
             }
         }

--- a/auth.js
+++ b/auth.js
@@ -2,84 +2,13 @@
 class AuthManager {
     constructor() {
         this.apiUrl = 'https://g8h3ilcvjnlq.manus.space/api';
-        this.guidesDatabase = this.loadGuidesDatabase();
+        // Base local de guias removida em favor da validação via API
         this.init();
     }
 
-    // Base de dados de guias válidos (simulada)
+    // Base local de guias descontinuada; validação agora via API
     loadGuidesDatabase() {
-        return [
-            {
-                name: "Carlos Silva Santos",
-                cadastur: "27123456789",
-                estado: "RJ",
-                especialidades: ["Montanha", "Trilhas"]
-            },
-            {
-                name: "Maria Fernanda Oliveira",
-                cadastur: "27987654321",
-                estado: "MG",
-                especialidades: ["Cachoeiras", "Ecoturismo"]
-            },
-            {
-                name: "João Pedro Montanha",
-                cadastur: "27456789123",
-                estado: "SP",
-                especialidades: ["Trekking", "Aventura"]
-            },
-            {
-                name: "Ana Carolina Rocha",
-                cadastur: "27789123456",
-                estado: "ES",
-                especialidades: ["Trilhas", "Natureza"]
-            },
-            {
-                name: "Roberto Carlos Lima",
-                cadastur: "27321654987",
-                estado: "BA",
-                especialidades: ["Montanha", "Expedições"]
-            },
-            {
-                name: "Fernanda Santos Costa",
-                cadastur: "27654987321",
-                estado: "PR",
-                especialidades: ["Ecoturismo", "Aventura"]
-            },
-            {
-                name: "Lucas Henrique Alves",
-                cadastur: "27147258369",
-                estado: "SC",
-                especialidades: ["Trilhas", "Montanha"]
-            },
-            {
-                name: "Juliana Pereira Souza",
-                cadastur: "27963852741",
-                estado: "GO",
-                especialidades: ["Natureza", "Trekking"]
-            },
-            {
-                name: "Rafael Augusto Ferreira",
-                cadastur: "27852741963",
-                estado: "RO",
-                especialidades: ["Expedições", "Aventura"]
-            },
-            {
-                name: "Camila Rodrigues Martins",
-                cadastur: "27741852963",
-                estado: "AM",
-                especialidades: ["Floresta", "Ecoturismo"]
-            },
-            {
-                name: "Julieli Ferrari dos Santos",
-                cadastur: "21467985879",
-                estado: "RS",
-                especialidades: [
-                    "Ecoturismo",
-                    "Turismo Cultural",
-                    "Turismo de Negócios e Eventos"
-                ]
-            }
-        ];
+        return [];
     }
 
     init() {
@@ -102,9 +31,8 @@ class AuthManager {
     // Configurar event listeners
     setupEventListeners() {
         console.log('Configurando event listeners...');
-        
-        // Aguardar um pouco para garantir que os elementos estejam carregados
-        setTimeout(() => {
+
+        const bindElements = () => {
             // Botoes de login/cadastro
             const loginBtn = document.getElementById('loginBtn');
             const registerBtn = document.getElementById('registerBtn');
@@ -124,14 +52,14 @@ class AuthManager {
                     this.openLoginModal();
                 });
             }
-            
+
             if (registerBtn) {
                 registerBtn.addEventListener('click', () => {
                     console.log('Abrindo modal de cadastro...');
                     this.openRegisterModal();
                 });
             }
-            
+
             if (logoutBtn) logoutBtn.addEventListener('click', () => this.logout());
             if (userMenuBtn) userMenuBtn.addEventListener('click', () => this.toggleUserDropdown());
 
@@ -142,7 +70,14 @@ class AuthManager {
                     if (dropdown) dropdown.classList.add('hidden');
                 }
             });
-        }, 100);
+        };
+
+        // Garantir que os elementos existam antes de vincular
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', bindElements);
+        } else {
+            bindElements();
+        }
     }
 
     // Mostrar menu do usuario
@@ -292,8 +227,7 @@ class AuthManager {
                             <label for="cadasturNumber" class="block text-sm font-medium text-red-600 mb-2">Número CADASTUR *</label>
                             <input type="text" id="cadasturNumber"
                                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
-                                   placeholder="Ex: 27123456789"
-                                   maxlength="11">
+                                   placeholder="Ex: 27123456789">
                             <p class="text-xs text-gray-500 mt-1">
                                 CADASTUR é o registro obrigatório para guias de turismo no Brasil. 
                                 <a href="https://cadastur.turismo.gov.br/" target="_blank" class="text-green-600 hover:text-green-700">Saiba mais</a>
@@ -381,8 +315,8 @@ class AuthManager {
             if (userTypeSelect.value === 'guia') {
                 cadasturSection.classList.remove('hidden');
                 cadasturInput.setAttribute('required', 'required');
-                // Validar dados existentes quando o tipo muda para guia
-                this.validateGuideData();
+                // Validar CADASTUR existente quando o tipo muda para guia
+                this.validateCadastur();
             } else {
                 cadasturSection.classList.add('hidden');
                 cadasturInput.removeAttribute('required');
@@ -391,10 +325,10 @@ class AuthManager {
             }
         });
 
-        // Validação em tempo real do nome para guias
+        // Limpar validação ao alterar o nome
         nameInput.addEventListener('input', () => {
             if (userTypeSelect.value === 'guia') {
-                this.validateGuideData();
+                this.clearValidation();
             }
         });
 
@@ -402,7 +336,7 @@ class AuthManager {
         cadasturInput.addEventListener('input', (e) => {
             this.formatCadastur(e.target);
             if (userTypeSelect.value === 'guia') {
-                this.validateGuideData();
+                this.validateCadastur();
             }
         });
 
@@ -412,101 +346,53 @@ class AuthManager {
         });
     }
 
-    // Validar dados do guia contra a base de dados
-    validateGuideData() {
-        const nameInput = document.getElementById('registerName');
+    // Validar número CADASTUR via API oficial
+    validateCadastur() {
         const cadasturInput = document.getElementById('cadasturNumber');
-        const nameValidation = document.getElementById('nameValidation');
         const cadasturValidation = document.getElementById('cadasturValidation');
         const validationSummary = document.getElementById('validationSummary');
-        const validationDetails = document.getElementById('validationDetails');
 
-        const name = nameInput.value.trim();
         const cadastur = cadasturInput.value.trim();
 
-        // Limpar validações anteriores
         this.clearValidation();
 
-        if (!name && !cadastur) {
+        if (!cadastur) {
+            cadasturValidation.innerHTML = '<span class="text-red-600">✗ CADASTUR é obrigatório para guias</span>';
+            cadasturInput.classList.add('border-red-300');
+            validationSummary.classList.add('hidden');
             return;
         }
 
-        // Buscar guia na base de dados
-        const guide = this.findGuideInDatabase(name, cadastur);
-
-        if (name && cadastur) {
-            if (guide) {
-                // Guia encontrado - validação bem-sucedida
-                nameValidation.innerHTML = '<span class="text-green-600">✓ Nome encontrado na base de dados</span>';
-                cadasturValidation.innerHTML = '<span class="text-green-600">✓ CADASTUR válido e verificado</span>';
-                
-                validationSummary.classList.remove('hidden');
-                validationDetails.innerHTML = `
-                    <div class="space-y-1">
-                        <div>✓ <strong>Nome:</strong> ${guide.name}</div>
-                        <div>✓ <strong>CADASTUR:</strong> ${guide.cadastur}</div>
-                        <div>✓ <strong>Estado:</strong> ${guide.estado}</div>
-                        <div>✓ <strong>Especialidades:</strong> ${guide.especialidades.join(', ')}</div>
-                    </div>
-                `;
-                
-                // Adicionar classe de sucesso aos campos
-                nameInput.classList.remove('border-red-300');
-                nameInput.classList.add('border-green-300');
-                cadasturInput.classList.remove('border-red-300');
-                cadasturInput.classList.add('border-green-300');
-                
-            } else {
-                // Guia não encontrado
-                nameValidation.innerHTML = '<span class="text-red-600">✗ Nome não encontrado na base de dados de guias certificados</span>';
-                cadasturValidation.innerHTML = '<span class="text-red-600">✗ CADASTUR não encontrado ou não corresponde ao nome</span>';
-                
-                validationSummary.classList.add('hidden');
-                
-                // Adicionar classe de erro aos campos
-                nameInput.classList.remove('border-green-300');
-                nameInput.classList.add('border-red-300');
-                cadasturInput.classList.remove('border-green-300');
-                cadasturInput.classList.add('border-red-300');
-            }
-        } else if (name) {
-            // Apenas nome preenchido
-            const nameMatches = this.guidesDatabase.filter(g => 
-                g.name.toLowerCase().includes(name.toLowerCase())
-            );
-            
-            if (nameMatches.length > 0) {
-                nameValidation.innerHTML = '<span class="text-yellow-600">⚠ Nome encontrado. Digite o CADASTUR para validação completa</span>';
-                nameInput.classList.remove('border-red-300');
-                nameInput.classList.add('border-yellow-300');
-            } else {
-                nameValidation.innerHTML = '<span class="text-red-600">✗ Nome não encontrado na base de dados</span>';
-                nameInput.classList.remove('border-green-300');
-                nameInput.classList.add('border-red-300');
-            }
-        } else if (cadastur && cadastur.length >= 10) {
-            // Apenas CADASTUR preenchido
-            const cadasturMatches = this.guidesDatabase.filter(g => g.cadastur === cadastur);
-            
-            if (cadasturMatches.length > 0) {
-                cadasturValidation.innerHTML = '<span class="text-yellow-600">⚠ CADASTUR encontrado. Confirme o nome completo</span>';
-                cadasturInput.classList.remove('border-red-300');
-                cadasturInput.classList.add('border-yellow-300');
-            } else {
-                cadasturValidation.innerHTML = '<span class="text-red-600">✗ CADASTUR não encontrado na base de dados</span>';
-                cadasturInput.classList.remove('border-green-300');
-                cadasturInput.classList.add('border-red-300');
-            }
+        if (!/^\d+$/.test(cadastur)) {
+            cadasturValidation.innerHTML = '<span class="text-red-600">✗ CADASTUR deve conter apenas números</span>';
+            cadasturInput.classList.add('border-red-300');
+            validationSummary.classList.add('hidden');
+            return;
         }
-    }
 
-    // Buscar guia na base de dados
-    findGuideInDatabase(name, cadastur) {
-        return this.guidesDatabase.find(guide => {
-            const nameMatch = guide.name.toLowerCase() === name.toLowerCase();
-            const cadasturMatch = guide.cadastur === cadastur;
-            return nameMatch && cadasturMatch;
-        });
+        fetch(`${this.apiUrl}/auth/validate-cadastur`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ cadastur_number: cadastur })
+        })
+            .then(resp => resp.json())
+            .then(result => {
+                if (result.valid) {
+                    cadasturValidation.innerHTML = '<span class="text-green-600">✓ CADASTUR válido e verificado</span>';
+                    cadasturInput.classList.remove('border-red-300');
+                    cadasturInput.classList.add('border-green-300');
+                } else {
+                    cadasturValidation.innerHTML = `<span class="text-red-600">✗ ${result.message || 'CADASTUR não encontrado na base oficial'}</span>`;
+                    cadasturInput.classList.remove('border-green-300');
+                    cadasturInput.classList.add('border-red-300');
+                }
+                validationSummary.classList.add('hidden');
+            })
+            .catch(() => {
+                cadasturValidation.innerHTML = '<span class="text-red-600">✗ Erro ao validar CADASTUR</span>';
+                cadasturInput.classList.add('border-red-300');
+                validationSummary.classList.add('hidden');
+            });
     }
 
     // Limpar validações
@@ -532,10 +418,7 @@ class AuthManager {
 
     // Formatar CADASTUR (apenas números)
     formatCadastur(input) {
-        let value = input.value.replace(/\D/g, '');
-        if (value.length > 11) {
-            value = value.substring(0, 11);
-        }
+        const value = input.value.replace(/\D/g, '');
         input.value = value;
     }
 
@@ -611,10 +494,20 @@ class AuthManager {
                 return;
             }
 
-            // Verificar se o guia está na base de dados
-            const guide = this.findGuideInDatabase(name, cadastur);
-            if (!guide) {
-                this.showError(errorDiv, 'Nome e CADASTUR não encontrados na base de dados de guias certificados. Apenas guias registrados podem se cadastrar como profissionais.');
+            try {
+                const resp = await fetch(`${this.apiUrl}/auth/validate-cadastur`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ cadastur_number: cadastur })
+                });
+                const result = await resp.json();
+                if (!result.valid) {
+                    this.showError(errorDiv, result.message || 'CADASTUR inválido');
+                    return;
+                }
+            } catch (err) {
+                console.error('Erro ao validar CADASTUR:', err);
+                this.showError(errorDiv, 'Erro ao validar CADASTUR. Tente novamente.');
                 return;
             }
         }
@@ -640,7 +533,7 @@ class AuthManager {
 
             // Adicionar CADASTUR se for guia
             if (userType === 'guia') {
-                userData.cadastur = cadastur;
+                userData.cadastur_number = cadastur;
             }
 
             const response = await fetch(`${this.apiUrl}/auth/register`, {

--- a/trekko_auth_backend/src/models/guia_cadastur.py
+++ b/trekko_auth_backend/src/models/guia_cadastur.py
@@ -1,0 +1,16 @@
+from src.database import db
+
+class GuiaCadastur(db.Model):
+    """Model for the guias_cadastur table"""
+    __tablename__ = 'guias_cadastur'
+
+    id = db.Column(db.Integer, primary_key=True)
+    numero_do_certificado = db.Column('número_do_certificado', db.String(20), unique=True, nullable=False)
+    nome_completo = db.Column('nome_completo', db.Text)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'numero_do_certificado': self.numero_do_certificado,
+            'nome_completo': self.nome_completo,
+        }

--- a/trekko_auth_backend/src/models/user.py
+++ b/trekko_auth_backend/src/models/user.py
@@ -60,16 +60,14 @@ class User(db.Model):
         if not cadastur_number:
             return False, "Número CADASTUR é obrigatório para guias"
         
-        # Remove non-digits
-        clean_cadastur = ''.join(filter(str.isdigit, cadastur_number))
-        
-        if len(clean_cadastur) != 11:
-            return False, "CADASTUR deve ter exatamente 11 dígitos"
-        
-        # Basic validation - could be enhanced with real CADASTUR validation
-        if clean_cadastur == '00000000000' or clean_cadastur == '11111111111':
+        clean_cadastur = cadastur_number.strip()
+
+        if not clean_cadastur.isdigit():
+            return False, "CADASTUR deve conter apenas números"
+
+        if len(set(clean_cadastur)) == 1:
             return False, "Número CADASTUR inválido"
-        
+
         return True, "CADASTUR válido"
     
     def __repr__(self):


### PR DESCRIPTION
## Summary
- drop bundled guide list in the client and validate CADASTUR through the API
- enforce numeric-only CADASTUR format without fixed length during client- and server-side checks
- ensure login and registration buttons bind only after DOM is ready

## Testing
- `npm test` *(fails: prisma: not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbdd3922e483248851de5873277705