### PR TITLE
Fix login and signup button functionality

### DIFF
--- a/auth-enhanced.js
+++ b/auth-enhanced.js
@@ -516,10 +516,6 @@ class TrekkoAuthManager {
             validationSummary.classList.add('hidden');
             return false;
         }
-            cadasturInput.classList.add('error');
-            validationSummary.classList.add('hidden');
-            return false;
-        }
 
         try {
             const resp = await fetch(`${this.apiUrl}/auth/validate-cadastur`, {


### PR DESCRIPTION
## Summary
- remove stray code causing syntax error in CADASTUR validation
- ensure auth script parses and binds login/cadastro buttons

## Testing
- `npm test` *(fails: prisma: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@prisma%2fclient)*

------
https://chatgpt.com/codex/tasks/task_e_68bbeb8094e4832480c8769a8a457298