### PR TITLE
fix: connect auth backend to mysql and improve cadastur validation

### DIFF
--- a/trekko_auth_backend/src/main.py
+++ b/trekko_auth_backend/src/main.py
@@ -18,7 +18,11 @@ CORS(app, resources={r"/api/*": {"origins": "*"}})
 app.register_blueprint(auth_bp)
 
 # Database configuration
-app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'database', 'app.db')}"
+database_url = os.getenv('DATABASE_URL')
+if database_url:
+    app.config['SQLALCHEMY_DATABASE_URI'] = database_url
+else:
+    app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'database', 'app.db')}"
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
 

--- a/trekko_auth_backend/src/models/user.py
+++ b/trekko_auth_backend/src/models/user.py
@@ -59,9 +59,12 @@ class User(db.Model):
         """Validate CADASTUR number format"""
         if not cadastur_number:
             return False, "Número CADASTUR é obrigatório para guias"
-        
 
-        if len(set(clean_cadastur)) == 1:
+        # Keep only digits
+        clean_cadastur = ''.join(filter(str.isdigit, cadastur_number))
+
+        # CADASTUR numbers have 11 digits and cannot be all the same
+        if len(clean_cadastur) != 11 or len(set(clean_cadastur)) == 1:
             return False, "Número CADASTUR inválido"
 
         return True, "CADASTUR válido"


### PR DESCRIPTION
## Summary
- support external DATABASE_URL and use MySQL when provided
- validate CADASTUR numbers with proper digit checks

## Testing
- `npm test` *(fails: prisma: not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbed9b3dc88324b971028f87913c2f