### PR TITLE
Use MySQL Cadastur data for guide validation

### DIFF
--- a/trekko_auth_backend/src/main.py
+++ b/trekko_auth_backend/src/main.py
@@ -19,10 +19,14 @@ app.register_blueprint(auth_bp)
 
 # Database configuration
 database_url = os.getenv('DATABASE_URL')
-if database_url:
-    app.config['SQLALCHEMY_DATABASE_URI'] = database_url
-else:
-    app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'database', 'app.db')}"
+if not database_url:
+    db_user = os.getenv('DB_USER', 'root')
+    db_password = os.getenv('DB_PASSWORD', '')
+    db_host = os.getenv('DB_HOST', 'localhost')
+    db_name = os.getenv('DB_NAME', 'trekko_db')
+    database_url = f"mysql+pymysql://{db_user}:{db_password}@{db_host}/{db_name}?charset=utf8mb4"
+
+app.config['SQLALCHEMY_DATABASE_URI'] = database_url
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
 

--- a/trekko_auth_backend/src/models/guia_cadastur.py
+++ b/trekko_auth_backend/src/models/guia_cadastur.py
@@ -8,6 +8,17 @@ class GuiaCadastur(db.Model):
     numero_do_certificado = db.Column('número_do_certificado', db.String(20), unique=True, nullable=False)
     nome_completo = db.Column('nome_completo', db.Text)
 
+    @staticmethod
+    def find_by_certificado(numero: str):
+        """Return first Cadastur entry matching the given certificate number.
+
+        The input may contain formatting characters; only digits are used for
+        the lookup so callers can pass values as typed by the user."""
+        clean = ''.join(filter(str.isdigit, numero))
+        if not clean:
+            return None
+        return GuiaCadastur.query.filter_by(numero_do_certificado=clean).first()
+
     def to_dict(self):
         return {
             'id': self.id,


### PR DESCRIPTION
## Summary
- connect backend to MySQL trekko_db when DATABASE_URL not set
- centralize Cadastur lookups in GuiaCadastur model and reuse in auth routes
- validate guide registration and CADASTUR check against official dataset

## Testing
- `python -m py_compile trekko_auth_backend/src/main.py trekko_auth_backend/src/routes/auth.py trekko_auth_backend/src/models/guia_cadastur.py trekko_auth_backend/src/models/user.py`
- `npm test` *(fails: prisma: not found)*
- `mysql -u root trekko_db < database/03a_insert_data_guias_cadastur_part1.sql` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf4d1bce4832498f5e76ad8f50c15