### PR TITLE
fix: validate CADASTUR against full guide base

### DIFF
--- a/trekko_auth_backend/src/models/guia_cadastur.py
+++ b/trekko_auth_backend/src/models/guia_cadastur.py
@@ -1,4 +1,6 @@
 from src.database import db
+from sqlalchemy import func
+from src.models.user import User
 
 class GuiaCadastur(db.Model):
     """Model for the guias_cadastur table"""
@@ -18,6 +20,22 @@ class GuiaCadastur(db.Model):
         if not clean:
             return None
         return GuiaCadastur.query.filter_by(numero_do_certificado=clean).first()
+
+    @staticmethod
+    def find_with_user(numero: str, nome: str):
+        """Fetch Cadastur entry and any associated user in a single query."""
+        clean = ''.join(filter(str.isdigit, numero))
+        if not clean or not nome:
+            return None
+        return (
+            db.session.query(GuiaCadastur, User)
+            .outerjoin(User, GuiaCadastur.numero_do_certificado == User.cadastur_number)
+            .filter(
+                GuiaCadastur.numero_do_certificado == clean,
+                func.lower(GuiaCadastur.nome_completo) == nome.lower()
+            )
+            .first()
+        )
 
     def to_dict(self):
         return {

--- a/trekko_auth_backend/src/routes/auth.py
+++ b/trekko_auth_backend/src/routes/auth.py
@@ -63,15 +63,16 @@ def register():
             if not is_valid:
                 return jsonify({'success': False, 'message': message}), 400
 
-            cadastur_entry = GuiaCadastur.find_by_certificado(cadastur_number)
-            if not cadastur_entry or not cadastur_entry.nome_completo or cadastur_entry.nome_completo.strip().lower() != name.lower():
+            result = GuiaCadastur.find_with_user(cadastur_number, name)
+            clean_cadastur = ''.join(filter(str.isdigit, cadastur_number))
+            if not result:
                 return jsonify({
                     'success': False,
                     'message': 'Número CADASTUR e nome não encontrados na base oficial'
                 }), 400
 
-            clean_cadastur = ''.join(filter(str.isdigit, cadastur_number))
-            if User.query.filter_by(cadastur_number=clean_cadastur).first():
+            guia_entry, existing_user = result
+            if existing_user is not None:
                 return jsonify({'success': False, 'message': 'Número CADASTUR já está em uso'}), 400
 
             cadastur_number = clean_cadastur
@@ -160,15 +161,16 @@ def validate_cadastur():
         clean_cadastur = ''.join(filter(str.isdigit, cadastur_number))
 
         if is_valid:
-            entry = GuiaCadastur.find_by_certificado(clean_cadastur)
-            if not entry or not entry.nome_completo or entry.nome_completo.strip().lower() != name.lower():
+            result = GuiaCadastur.find_with_user(clean_cadastur, name)
+            if not result:
                 is_valid = False
                 message = "Número CADASTUR e nome não encontrados na base oficial"
+            else:
+                guia_entry, existing_user = result
+                if existing_user is not None:
+                    is_valid = False
+                    message = "Número CADASTUR já está em uso"
 
-        if is_valid and User.query.filter_by(cadastur_number=clean_cadastur).first():
-            is_valid = False
-            message = "Número CADASTUR já está em uso"
-        
         return jsonify({
             'valid': is_valid,
             'message': message


### PR DESCRIPTION
## Summary
- join Cadastur guides with existing users when checking certificate and name
- reuse shared query to validate Cadastur number availability

## Testing
- `npm test` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfc3e37508324b21d2c72acd88267