### PR TITLE
fix: validate CADASTUR against full guide base

### DIFF
--- a/trekko_auth_backend/src/models/guia_cadastur.py
+++ b/trekko_auth_backend/src/models/guia_cadastur.py
@@ -1,4 +1,8 @@
 from src.database import db
+from src.models.user import User
+import unicodedata
+import re
+
 
 class GuiaCadastur(db.Model):
     """Model for the guias_cadastur table"""
@@ -19,9 +23,40 @@ class GuiaCadastur(db.Model):
             return None
         return GuiaCadastur.query.filter_by(numero_do_certificado=clean).first()
 
+    @staticmethod
+    def _normalize_name(nome: str) -> str:
+        """Return a case-insensitive, accent-free representation of a name."""
+        if not nome:
+            return ""
+        normalized = unicodedata.normalize("NFD", nome)
+        without_accents = "".join(c for c in normalized if not unicodedata.combining(c))
+        return re.sub(r"\s+", " ", without_accents).strip().lower()
+
+    @staticmethod
+    def names_match(registry_name: str, provided_name: str) -> bool:
+        """Compare two names ignoring case, accents and extra spaces."""
+        return (
+            GuiaCadastur._normalize_name(registry_name)
+            == GuiaCadastur._normalize_name(provided_name)
+        )
+
+    @staticmethod
+    def find_with_user(numero: str):
+        """Fetch Cadastur entry and any associated user in a single query."""
+        clean = ''.join(filter(str.isdigit, numero))
+        if not clean:
+            return None
+        return (
+            db.session.query(GuiaCadastur, User)
+            .outerjoin(User, GuiaCadastur.numero_do_certificado == User.cadastur_number)
+            .filter(GuiaCadastur.numero_do_certificado == clean)
+            .first()
+        )
+
     def to_dict(self):
         return {
             'id': self.id,
             'numero_do_certificado': self.numero_do_certificado,
             'nome_completo': self.nome_completo,
         }
+


### PR DESCRIPTION
## Summary
- normalize Cadastur names to ignore accents and extra spaces
- verify guide certificate against registry before allowing new user or validating endpoint

## Testing
- `npm test` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfc3e37508324b21d2c72acd88267