### PR TITLE
Ajusta validação de CADASTUR apenas pelo código

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -209,7 +209,7 @@ class TrekkoAuth {
         const data = Object.fromEntries(formData);
 
         if (data.user_type === 'guia') {
-            const isValid = await this.validateCadasturAPI(data.cadastur_number, data.name);
+            const isValid = await this.validateCadasturAPI(data.cadastur_number);
             if (!isValid) {
                 return;
             }
@@ -260,12 +260,12 @@ class TrekkoAuth {
         return true;
     }
 
-    async validateCadasturAPI(cadasturNumber, name) {
+    async validateCadasturAPI(cadasturNumber) {
         try {
             const response = await fetch(`${this.apiUrl}/validate-cadastur`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ cadastur_number: cadasturNumber, name })
+                body: JSON.stringify({ cadastur_number: cadasturNumber })
             });
 
             const result = await response.json();


### PR DESCRIPTION
## Summary
- remove verificaçao de nome ao validar CADASTUR
- atualiza frontend para consultar apenas o número CADASTUR

## Testing
- `python -m py_compile trekko_auth_backend/src/routes/auth.py`
- `npm test` *(fails: prisma not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc00dfe7408324b254a8c47e3b208f