### PR TITLE
feat: add basic rbac to admin

### DIFF
--- a/admin-auth.js
+++ b/admin-auth.js
@@ -1,29 +1,75 @@
-// admin-auth.js - restrição de acesso a administradores
+// admin-auth.js - controle de acesso e permissões básicas da área administrativa
 class AdminGuard {
   static adminEmails = ['contato@trekko.com.br'];
+  static allowedRoles = ['ADMIN', 'EDITOR', 'OPERADOR'];
 
-  static check() {
+  /**
+   * Valida a existência de sessão e retorna o usuário autenticado.
+   * Caso não haja usuário válido, faz o redirecionamento para o site público.
+   */
+  static requireAuth() {
     const data = localStorage.getItem('userData');
     if (!data) {
       alert('Acesso restrito. Faça login como administrador.');
       window.location.href = 'https://www.trekko.com.br/';
-      return;
+      return null;
     }
     try {
       const user = JSON.parse(data);
-      const isAdmin =
-        user.role === 'admin' ||
-        user.role === 'ADMIN' ||
+      const hasRole =
+        AdminGuard.allowedRoles.includes(user.role) ||
         AdminGuard.adminEmails.includes(user.email);
-      if (!isAdmin) {
+      if (!hasRole) {
         alert('Apenas administradores podem acessar esta área.');
         window.location.href = 'https://www.trekko.com.br/';
+        return null;
       }
+      return user;
     } catch {
       localStorage.removeItem('userData');
       window.location.href = 'https://www.trekko.com.br/';
+      return null;
     }
   }
 }
 
-document.addEventListener('DOMContentLoaded', AdminGuard.check);
+/**
+ * Gerencia permissões na UI através do atributo `data-permission`.
+ * Elementos sem permissão ficam desabilitados.
+ */
+class PermissionManager {
+  static rules = {
+    ADMIN: ['*'],
+    EDITOR: [
+      'CMS',
+      'TRILHAS',
+      'EXPEDICOES',
+      'GUIAS',
+      'CLIENTES',
+      'RESERVAS',
+      'INTEGRACOES',
+      'CONFIGURACOES',
+    ],
+    OPERADOR: ['EXPEDICOES', 'RESERVAS', 'CLIENTES', 'GUIAS'],
+  };
+
+  static apply(role) {
+    const permissions = PermissionManager.rules[role] || [];
+    const allowAll = permissions.includes('*');
+    document.querySelectorAll('[data-permission]').forEach((el) => {
+      const required = el.getAttribute('data-permission');
+      const allowed = allowAll || permissions.includes(required);
+      if (!allowed) {
+        el.classList.add('pointer-events-none', 'opacity-50');
+        el.setAttribute('title', 'Permissão insuficiente');
+      }
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const user = AdminGuard.requireAuth();
+  if (user) {
+    PermissionManager.apply(user.role);
+  }
+});

--- a/admin.html
+++ b/admin.html
@@ -15,29 +15,29 @@
       <h1 class="text-xl font-bold mb-6">Trekko Admin</h1>
       <nav class="space-y-4">
         <div>
-          <a href="admin.html" class="block text-gray-700 hover:text-green-600">Dashboard</a>
+          <a href="admin.html" class="block text-gray-700 hover:text-green-600" data-permission="DASHBOARD">Dashboard</a>
         </div>
         <div>
-          <a href="guias.html" class="block text-gray-700 hover:text-green-600">Usuários &amp; Guias</a>
+          <a href="guias.html" class="block text-gray-700 hover:text-green-600" data-permission="GUIAS">Usuários &amp; Guias</a>
         </div>
         <div>
-          <a href="trilhas.html" class="block text-gray-700 hover:text-green-600">Trilhas</a>
+          <a href="trilhas.html" class="block text-gray-700 hover:text-green-600" data-permission="TRILHAS">Trilhas</a>
         </div>
         <div>
-          <a href="admin-expeditions.html" class="block text-gray-700 hover:text-green-600">Expedições</a>
+          <a href="admin-expeditions.html" class="block text-gray-700 hover:text-green-600" data-permission="EXPEDICOES">Expedições</a>
         </div>
         <div>
-          <a href="#" class="block text-gray-700 hover:text-green-600">Financeiro</a>
+          <a href="#" class="block text-gray-700 hover:text-green-600" data-permission="FINANCEIRO">Financeiro</a>
         </div>
         <div>
-          <a href="#" class="block text-gray-700 hover:text-green-600">CMS</a>
+          <a href="#" class="block text-gray-700 hover:text-green-600" data-permission="CMS">CMS</a>
         </div>
         <div>
           <p class="text-xs text-gray-400 uppercase mb-1">Integrações</p>
-          <a href="#" class="block font-medium text-green-700" id="link-cadastur">Cadastur (CSV)</a>
+          <a href="#" class="block font-medium text-green-700" id="link-cadastur" data-permission="INTEGRACOES">Cadastur (CSV)</a>
         </div>
         <div>
-          <a href="#" class="block text-gray-700 hover:text-green-600">Configurações</a>
+          <a href="#" class="block text-gray-700 hover:text-green-600" data-permission="CONFIGURACOES">Configurações</a>
         </div>
       </nav>
     </div>
@@ -50,7 +50,7 @@
         <h2 class="text-2xl font-bold" id="section-title">Cadastur (CSV)</h2>
         <nav class="text-sm text-gray-500">Integrações / Cadastur</nav>
       </div>
-      <button id="exportCsv" class="bg-green-600 text-white px-4 py-2 rounded hidden">Exportar CSV</button>
+      <button id="exportCsv" class="bg-green-600 text-white px-4 py-2 rounded hidden" data-permission="INTEGRACOES">Exportar CSV</button>
     </header>
 
     <main id="content" class="p-6 flex-1 space-y-8 overflow-y-auto">
@@ -77,7 +77,7 @@
             <label class="flex items-center"><input id="replaceBase" type="checkbox" class="mr-2" />Substituir base atual</label>
             <label class="flex items-center"><input id="softDelete" type="checkbox" class="mr-2" />Desativar guias não presentes no novo CSV</label>
           </div>
-          <button id="validateBtn" class="mt-4 bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50" disabled>Validar arquivo</button>
+          <button id="validateBtn" class="mt-4 bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50" disabled data-permission="INTEGRACOES">Validar arquivo</button>
           <div id="validationArea" class="mt-6 hidden">
             <h4 class="font-medium mb-2">Preview</h4>
             <div class="overflow-x-auto">
@@ -116,7 +116,7 @@
         <!-- Execução -->
         <div>
           <h3 class="text-xl font-semibold mb-2">Execução</h3>
-          <button id="executeBtn" class="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50" disabled>Executar Importação</button>
+          <button id="executeBtn" class="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50" disabled data-permission="INTEGRACOES">Executar Importação</button>
         </div>
 
         <!-- Resultado -->


### PR DESCRIPTION
## Summary
- add role-based permission manager to admin auth script
- annotate admin links/actions with permission metadata

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c82cf5fc2083248e1dd2f95656c245