### PR TITLE
feat: redesign admin dashboard overview

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -6,7 +6,7 @@
   <title>Trekko Admin</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="admin-auth.js" defer></script>
-  <script src="js/admin-cadastur.js" defer></script>
+  <script src="js/admin-dashboard.js" defer></script>
 </head>
 <body class="flex bg-gray-50">
   <!-- Sidebar -->
@@ -47,108 +47,161 @@
   <div class="flex-1 ml-64 min-h-screen flex flex-col">
     <header class="bg-white border-b p-4 flex items-center justify-between">
       <div>
-        <h2 class="text-2xl font-bold" id="section-title">Cadastur (CSV)</h2>
-        <nav class="text-sm text-gray-500">Integrações / Cadastur</nav>
+        <h2 class="text-2xl font-bold" id="section-title">Dashboard</h2>
+        <nav class="text-sm text-gray-500">Início / Dashboard</nav>
       </div>
-      <button id="exportCsv" class="bg-green-600 text-white px-4 py-2 rounded hidden" data-permission="INTEGRACOES">Exportar CSV</button>
+      <div class="flex items-center space-x-3">
+        <span id="refreshStatus" class="text-sm text-gray-500 hidden">Atualizando...</span>
+        <button id="refreshDashboard" class="bg-green-600 text-white px-4 py-2 rounded" data-permission="DASHBOARD">Atualizar</button>
+      </div>
     </header>
 
-    <main id="content" class="p-6 flex-1 space-y-8 overflow-y-auto">
-      <!-- Cadastur section -->
-      <section id="cadastur-section" class="space-y-10">
-        <!-- Instruções & Template -->
-        <div>
-          <h3 class="text-xl font-semibold mb-2">Instruções &amp; Template</h3>
-          <p class="text-sm text-gray-600">O arquivo deve estar em UTF-8, separado por vírgula e conter os cabeçalhos corretos.</p>
-          <div class="mt-4 flex space-x-2">
-            <button id="downloadTemplate" class="bg-gray-200 px-4 py-2 rounded">Baixar Template CSV</button>
-            <button id="downloadBase" class="bg-gray-200 px-4 py-2 rounded">Baixar Base Atual</button>
+    <main id="content" class="p-6 flex-1 space-y-10 overflow-y-auto">
+      <section aria-labelledby="overviewTitle" class="space-y-4">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+          <div>
+            <h3 id="overviewTitle" class="text-xl font-semibold text-gray-900">Visão Geral</h3>
+            <p class="text-sm text-gray-500">
+              Indicadores consolidados das operações. Garantimos atualização em até
+              <span class="font-medium text-gray-700" data-sla></span>.
+            </p>
           </div>
+          <div id="metricsMeta" class="text-sm text-gray-500">Carregando indicadores...</div>
         </div>
-
-        <!-- Upload & Validação -->
-        <div>
-          <h3 class="text-xl font-semibold mb-2">Upload &amp; Validação</h3>
-          <div id="dropzone" class="border-2 border-dashed border-gray-300 rounded p-6 text-center cursor-pointer">
-            <p class="text-gray-500">Arraste o CSV aqui ou clique para selecionar</p>
-            <input id="fileInput" type="file" accept=".csv" class="hidden" />
-          </div>
-          <div class="mt-4 space-y-2">
-            <label class="flex items-center"><input id="replaceBase" type="checkbox" class="mr-2" />Substituir base atual</label>
-            <label class="flex items-center"><input id="softDelete" type="checkbox" class="mr-2" />Desativar guias não presentes no novo CSV</label>
-          </div>
-          <button id="validateBtn" class="mt-4 bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50" disabled data-permission="INTEGRACOES">Validar arquivo</button>
-          <div id="validationArea" class="mt-6 hidden">
-            <h4 class="font-medium mb-2">Preview</h4>
-            <div class="overflow-x-auto">
-              <table class="min-w-full text-sm text-left" id="previewTable">
-                <thead></thead>
-                <tbody></tbody>
-              </table>
+        <p id="metricsValidation" class="text-xs text-gray-500">Reconciliando com relatórios...</p>
+        <div id="metricsError" class="text-sm text-red-600 bg-red-50 border border-red-100 px-4 py-3 rounded hidden"></div>
+        <div id="metricsGrid" class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 gap-4">
+          <article class="bg-white rounded-lg shadow-sm p-5 border border-gray-100">
+            <div class="flex items-start justify-between">
+              <div>
+                <h4 class="text-sm text-gray-500 uppercase tracking-wide">Trilhas</h4>
+                <p id="metric-trails" class="text-3xl font-bold text-gray-900 mt-2">--</p>
+              </div>
+              <span class="text-3xl" aria-hidden="true">🥾</span>
             </div>
-            <div id="errorList" class="text-red-600 mt-4"></div>
-          </div>
+            <p class="mt-3 text-xs text-gray-400">Total de trilhas publicadas.</p>
+          </article>
+          <article class="bg-white rounded-lg shadow-sm p-5 border border-gray-100">
+            <div class="flex items-start justify-between">
+              <div>
+                <h4 class="text-sm text-gray-500 uppercase tracking-wide">Expedições</h4>
+                <p id="metric-expeditions" class="text-3xl font-bold text-gray-900 mt-2">--</p>
+              </div>
+              <span class="text-3xl" aria-hidden="true">🧭</span>
+            </div>
+            <p class="mt-3 text-xs text-gray-400">Expedições ativas e planejadas.</p>
+          </article>
+          <article class="bg-white rounded-lg shadow-sm p-5 border border-gray-100">
+            <div class="flex items-start justify-between">
+              <div>
+                <h4 class="text-sm text-gray-500 uppercase tracking-wide">Guias ativos</h4>
+                <p id="metric-active-guides" class="text-3xl font-bold text-gray-900 mt-2">--</p>
+              </div>
+              <span class="text-3xl" aria-hidden="true">🧑‍✈️</span>
+            </div>
+            <p class="mt-3 text-xs text-gray-400">Guias com documentação verificada.</p>
+          </article>
+          <article class="bg-white rounded-lg shadow-sm p-5 border border-gray-100">
+            <div class="flex items-start justify-between">
+              <div>
+                <h4 class="text-sm text-gray-500 uppercase tracking-wide">Reservas</h4>
+                <p id="metric-reservations" class="text-3xl font-bold text-gray-900 mt-2">--</p>
+              </div>
+              <span class="text-3xl" aria-hidden="true">📅</span>
+            </div>
+            <p class="mt-3 text-xs text-gray-400">Reservas confirmadas para as próximas saídas.</p>
+          </article>
+          <article class="bg-white rounded-lg shadow-sm p-5 border border-gray-100">
+            <div class="flex items-start justify-between">
+              <div>
+                <h4 class="text-sm text-gray-500 uppercase tracking-wide">Receita</h4>
+                <p id="metric-revenue" class="text-3xl font-bold text-gray-900 mt-2">--</p>
+              </div>
+              <span class="text-3xl" aria-hidden="true">💰</span>
+            </div>
+            <p class="mt-3 text-xs text-gray-400">Receita líquida confirmada no período.</p>
+          </article>
         </div>
+      </section>
 
-        <!-- Resumo -->
-        <div id="summarySection" class="hidden">
-          <h3 class="text-xl font-semibold mb-2">Resumo da Reconciliação (simulação)</h3>
-          <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <div class="p-4 bg-white rounded shadow">
-              <p class="text-sm">Novos</p>
-              <p id="countNovos" class="text-2xl font-bold">0</p>
+      <section aria-labelledby="shortcutsTitle" class="space-y-4">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+          <h3 id="shortcutsTitle" class="text-xl font-semibold text-gray-900">Atalhos de criação rápida</h3>
+          <p class="text-sm text-gray-500">Inicie novos cadastros sem sair do painel.</p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <button type="button" class="bg-white border border-gray-100 rounded-lg shadow-sm p-5 text-left hover:border-green-500 transition" data-quick-action="trail" data-permission="TRILHAS">
+            <div class="flex items-start justify-between">
+              <div>
+                <p class="text-sm text-gray-500 uppercase tracking-wide">Nova trilha</p>
+                <p class="mt-2 text-lg font-semibold text-gray-900">Cadastrar trilha</p>
+                <p class="mt-1 text-sm text-gray-500">Título, localização e nível de dificuldade.</p>
+              </div>
+              <span class="text-3xl" aria-hidden="true">🥾</span>
             </div>
-            <div class="p-4 bg-white rounded shadow">
-              <p class="text-sm">Atualizados</p>
-              <p id="countAtualizados" class="text-2xl font-bold">0</p>
+          </button>
+          <button type="button" class="bg-white border border-gray-100 rounded-lg shadow-sm p-5 text-left hover:border-green-500 transition" data-quick-action="expedition" data-permission="EXPEDICOES">
+            <div class="flex items-start justify-between">
+              <div>
+                <p class="text-sm text-gray-500 uppercase tracking-wide">Nova expedição</p>
+                <p class="mt-2 text-lg font-semibold text-gray-900">Abrir turma</p>
+                <p class="mt-1 text-sm text-gray-500">Datas, vagas e guia responsável.</p>
+              </div>
+              <span class="text-3xl" aria-hidden="true">🧗</span>
             </div>
-            <div class="p-4 bg-white rounded shadow">
-              <p class="text-sm">Sem mudança</p>
-              <p id="countSemMudanca" class="text-2xl font-bold">0</p>
+          </button>
+          <button type="button" class="bg-white border border-gray-100 rounded-lg shadow-sm p-5 text-left hover:border-green-500 transition" data-quick-action="post" data-permission="CMS">
+            <div class="flex items-start justify-between">
+              <div>
+                <p class="text-sm text-gray-500 uppercase tracking-wide">Novo post</p>
+                <p class="mt-2 text-lg font-semibold text-gray-900">Publicar conteúdo</p>
+                <p class="mt-1 text-sm text-gray-500">Título, slug e status de publicação.</p>
+              </div>
+              <span class="text-3xl" aria-hidden="true">📝</span>
             </div>
-            <div class="p-4 bg-white rounded shadow">
-              <p class="text-sm">A desativar</p>
-              <p id="countDesativar" class="text-2xl font-bold">0</p>
-            </div>
+          </button>
+        </div>
+      </section>
+
+      <section aria-labelledby="eventsTitle" class="space-y-4">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+          <div>
+            <h3 id="eventsTitle" class="text-xl font-semibold text-gray-900">Últimos eventos do sistema</h3>
+            <p class="text-sm text-gray-500">Monitoramento em tempo real das operações críticas.</p>
           </div>
+          <div id="eventsMeta" class="text-sm text-gray-500">Carregando eventos...</div>
         </div>
-
-        <!-- Execução -->
-        <div>
-          <h3 class="text-xl font-semibold mb-2">Execução</h3>
-          <button id="executeBtn" class="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50" disabled data-permission="INTEGRACOES">Executar Importação</button>
-        </div>
-
-        <!-- Resultado -->
-        <div id="resultSection" class="hidden">
-          <h3 class="text-xl font-semibold mb-2">Resultado</h3>
-          <div id="resultMessage" class="p-4 bg-green-50 border border-green-200 rounded"></div>
-          <button id="rollbackBtn" class="mt-4 bg-red-600 text-white px-4 py-2 rounded hidden">Desfazer (Rollback)</button>
-        </div>
-
-        <!-- Histórico de Imports -->
-        <div>
-          <h3 class="text-xl font-semibold mb-2">Histórico de Imports</h3>
-          <div class="overflow-x-auto">
-            <table class="min-w-full text-sm text-left" id="historyTable">
-              <thead>
-                <tr class="bg-gray-100">
-                  <th class="px-4 py-2">Data/Hora</th>
-                  <th class="px-4 py-2">Ator</th>
-                  <th class="px-4 py-2">Novos</th>
-                  <th class="px-4 py-2">Atualizados</th>
-                  <th class="px-4 py-2">Desativados</th>
-                  <th class="px-4 py-2">Arquivo</th>
-                  <th class="px-4 py-2">Status</th>
-                  <th class="px-4 py-2">Ações</th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
+        <div id="eventsError" class="text-sm text-red-600 bg-red-50 border border-red-100 px-4 py-3 rounded hidden"></div>
+        <div class="bg-white border border-gray-100 rounded-lg shadow-sm">
+          <div id="eventsSkeleton" class="p-6 text-sm text-gray-500 flex items-center space-x-3">
+            <span class="inline-block h-3 w-3 rounded-full bg-green-500 animate-pulse"></span>
+            <span>Sincronizando com o sistema...</span>
           </div>
+          <ul id="eventsList" class="divide-y divide-gray-100 hidden"></ul>
+          <div id="eventsEmpty" class="p-6 text-sm text-gray-500 hidden">Nenhum evento recente nas últimas horas.</div>
         </div>
       </section>
     </main>
+  </div>
+
+  <div id="quickActionModal" class="hidden fixed inset-0 bg-gray-900/60 z-50 items-center justify-center p-4">
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-xl" role="dialog" aria-modal="true" aria-labelledby="quickActionModalTitle">
+      <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+        <h4 id="quickActionModalTitle" class="text-lg font-semibold text-gray-900"></h4>
+        <button id="quickActionModalClose" type="button" class="text-gray-500 hover:text-gray-700">
+          <span class="sr-only">Fechar</span>
+          ✕
+        </button>
+      </div>
+      <form id="quickActionForm" class="px-6 py-4 space-y-4">
+        <div id="quickActionFields" class="space-y-4"></div>
+        <p id="quickActionFeedback" class="text-sm hidden"></p>
+        <div class="flex items-center justify-end space-x-2 pt-2 border-t border-gray-200">
+          <button id="quickActionCancel" type="button" class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">Cancelar</button>
+          <button id="quickActionSubmit" type="submit" class="px-4 py-2 bg-green-600 text-white text-sm font-semibold rounded">Salvar</button>
+        </div>
+      </form>
+    </div>
   </div>
 </body>
 </html>

--- a/js/admin-dashboard.js
+++ b/js/admin-dashboard.js
@@ -1,0 +1,716 @@
+// js/admin-dashboard.js
+// Dashboard principal da área administrativa: carregamento de métricas, eventos
+// e atalhos para criação rápida.
+
+const DASHBOARD_SLA_SECONDS = 4;
+const DASHBOARD_TIMEOUT = DASHBOARD_SLA_SECONDS * 1000;
+
+const DASHBOARD_ENDPOINTS = {
+  metrics: '/api/admin/dashboard/metrics',
+  events: '/api/admin/dashboard/events',
+  quickActions: {
+    trail: '/api/admin/trails',
+    expedition: '/api/admin/expeditions',
+    post: '/api/admin/posts',
+  },
+};
+
+const STORAGE_KEYS = {
+  metrics: 'trekko.dashboard.metrics',
+  events: 'trekko.dashboard.events',
+};
+
+const METRIC_LABELS = {
+  trails: 'Trilhas',
+  expeditions: 'Expedições',
+  activeGuides: 'Guias ativos',
+  reservations: 'Reservas',
+  revenue: 'Receita',
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const user = typeof AdminGuard !== 'undefined' ? AdminGuard.requireAuth() : null;
+  if (!user) {
+    return;
+  }
+
+  document.querySelectorAll('[data-sla]').forEach((el) => {
+    el.textContent = `${DASHBOARD_SLA_SECONDS}s`;
+  });
+
+  const metricsMeta = document.getElementById('metricsMeta');
+  const metricsValidation = document.getElementById('metricsValidation');
+  const metricsError = document.getElementById('metricsError');
+
+  const eventsMeta = document.getElementById('eventsMeta');
+  const eventsError = document.getElementById('eventsError');
+  const eventsSkeleton = document.getElementById('eventsSkeleton');
+  const eventsList = document.getElementById('eventsList');
+  const eventsEmpty = document.getElementById('eventsEmpty');
+
+  const refreshButton = document.getElementById('refreshDashboard');
+  const refreshStatus = document.getElementById('refreshStatus');
+
+  const metricsState = {
+    values: {
+      trails: 0,
+      expeditions: 0,
+      activeGuides: 0,
+      reservations: 0,
+      revenue: 0,
+    },
+    payload: null,
+  };
+
+  function setRefreshInProgress(inProgress) {
+    if (!refreshButton || !refreshStatus) return;
+    refreshButton.disabled = inProgress;
+    refreshButton.classList.toggle('opacity-60', inProgress);
+    refreshStatus.classList.toggle('hidden', !inProgress);
+  }
+
+  async function loadMetrics() {
+    const start = performance.now();
+    hideElement(metricsError);
+    if (metricsMeta) {
+      metricsMeta.textContent = 'Carregando indicadores...';
+    }
+    if (metricsValidation) {
+      metricsValidation.textContent = 'Reconciliando com relatórios...';
+      metricsValidation.classList.remove('text-red-600', 'text-emerald-600', 'text-amber-600');
+      metricsValidation.classList.add('text-gray-500');
+    }
+
+    const cached = readFromStorage(STORAGE_KEYS.metrics);
+
+    try {
+      const response = await fetchWithTimeout(DASHBOARD_ENDPOINTS.metrics);
+      if (!response.ok) {
+        throw new Error(`Falha ao buscar métricas (${response.status})`);
+      }
+      const payload = await parseJsonSafely(response);
+      const normalized = normalizeMetrics(payload);
+      applyMetricValues(normalized);
+      metricsState.values = normalized;
+      metricsState.payload = payload;
+
+      const updatedAt = payload?.lastUpdated || payload?.updatedAt || payload?.generatedAt || new Date().toISOString();
+      const duration = performance.now() - start;
+      updateMetricsMeta({ updatedAt, duration });
+      validateMetricsAgainstReports(payload, normalized);
+
+      saveToStorage(STORAGE_KEYS.metrics, {
+        totals: normalized,
+        fetchedAt: new Date().toISOString(),
+        payloadMeta: {
+          lastUpdated: updatedAt,
+          reportSnapshot: payload?.reportTotals || payload?.reports || payload?.reportSummary || null,
+        },
+      });
+    } catch (error) {
+      console.error('Falha ao carregar métricas', error);
+      if (cached?.totals) {
+        applyMetricValues(cached.totals);
+        const duration = performance.now() - start;
+        updateMetricsMeta({
+          updatedAt: cached.payloadMeta?.lastUpdated || cached.fetchedAt,
+          duration,
+          fromCache: true,
+        });
+        if (metricsValidation) {
+          metricsValidation.textContent = 'Exibindo dados em cache. Valide com o relatório oficial.';
+          metricsValidation.classList.remove('text-gray-500', 'text-emerald-600');
+          metricsValidation.classList.add('text-amber-600');
+        }
+      } else {
+        applyMetricValues({ trails: 0, expeditions: 0, activeGuides: 0, reservations: 0, revenue: 0 });
+        if (metricsMeta) {
+          metricsMeta.textContent = 'Não foi possível carregar os indicadores.';
+        }
+        if (metricsValidation) {
+          metricsValidation.textContent = 'Indicadores indisponíveis. Sem dados para reconciliar.';
+          metricsValidation.classList.remove('text-gray-500', 'text-emerald-600');
+          metricsValidation.classList.add('text-red-600');
+        }
+        if (metricsError) {
+          metricsError.textContent = 'Erro ao conectar com o serviço de métricas. Tente novamente mais tarde.';
+          showElement(metricsError);
+        }
+      }
+    }
+  }
+
+  async function loadEvents() {
+    hideElement(eventsError);
+    if (eventsSkeleton) showElement(eventsSkeleton);
+    if (eventsList) hideElement(eventsList);
+    if (eventsEmpty) hideElement(eventsEmpty);
+    if (eventsMeta) {
+      eventsMeta.textContent = 'Carregando eventos...';
+    }
+
+    const cached = readFromStorage(STORAGE_KEYS.events);
+
+    try {
+      const response = await fetchWithTimeout(DASHBOARD_ENDPOINTS.events);
+      if (!response.ok) {
+        throw new Error(`Falha ao buscar eventos (${response.status})`);
+      }
+      const payload = await parseJsonSafely(response);
+      const events = normalizeEvents(payload);
+      renderEvents(events);
+      if (eventsSkeleton) hideElement(eventsSkeleton);
+      if (eventsList) toggleElement(eventsList, events.length > 0);
+      if (eventsEmpty) toggleElement(eventsEmpty, events.length === 0);
+
+      const referenceDate = events.length ? events[0].timestamp : payload?.lastEventAt;
+      if (eventsMeta) {
+        eventsMeta.textContent = referenceDate
+          ? `Atualizado em ${formatDateTime(referenceDate)}`
+          : 'Eventos sincronizados.';
+      }
+
+      saveToStorage(STORAGE_KEYS.events, {
+        events,
+        fetchedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      console.error('Falha ao carregar eventos', error);
+      if (eventsSkeleton) hideElement(eventsSkeleton);
+      if (cached?.events?.length) {
+        renderEvents(cached.events);
+        if (eventsList) showElement(eventsList);
+        if (eventsEmpty) hideElement(eventsEmpty);
+        if (eventsMeta) {
+          eventsMeta.textContent = `Exibindo eventos em cache (${formatDateTime(cached.fetchedAt)}).`;
+        }
+      } else {
+        if (eventsError) {
+          eventsError.textContent = 'Não foi possível carregar os eventos recentes.';
+          showElement(eventsError);
+        }
+        if (eventsEmpty) showElement(eventsEmpty);
+        if (eventsMeta) {
+          eventsMeta.textContent = 'Eventos indisponíveis.';
+        }
+      }
+    }
+  }
+
+  function applyMetricValues(values) {
+    setText('metric-trails', formatNumber(values.trails));
+    setText('metric-expeditions', formatNumber(values.expeditions));
+    setText('metric-active-guides', formatNumber(values.activeGuides));
+    setText('metric-reservations', formatNumber(values.reservations));
+    setText('metric-revenue', formatCurrency(values.revenue));
+  }
+
+  function updateMetricsMeta({ updatedAt, duration, fromCache }) {
+    if (!metricsMeta) return;
+    const parts = [];
+    if (updatedAt) parts.push(`Atualizado em ${formatDateTime(updatedAt)}`);
+    if (typeof duration === 'number') parts.push(`Carregado em ${(duration / 1000).toFixed(1)} s`);
+    if (fromCache) parts.push('Usando dados em cache');
+    parts.push(`SLA ${DASHBOARD_SLA_SECONDS}s`);
+    metricsMeta.textContent = parts.join(' · ');
+  }
+
+  function validateMetricsAgainstReports(payload, metrics) {
+    if (!metricsValidation) return;
+    const reportTotals = payload?.reportTotals || payload?.reports || payload?.reportSummary;
+    if (!reportTotals) {
+      metricsValidation.textContent = 'Aguardando consolidação dos relatórios.';
+      metricsValidation.classList.remove('text-red-600', 'text-emerald-600', 'text-amber-600');
+      metricsValidation.classList.add('text-gray-500');
+      return;
+    }
+
+    const normalizedReports = {
+      trails: readFirstNumber(reportTotals, ['trails', 'totalTrails', 'trailCount', 'trilhas']),
+      expeditions: readFirstNumber(reportTotals, ['expeditions', 'totalExpeditions', 'expeditionCount', 'expedicoes']),
+      activeGuides: readFirstNumber(reportTotals, ['activeGuides', 'guides', 'guiaAtivos', 'totalGuides']),
+      reservations: readFirstNumber(reportTotals, ['reservations', 'totalReservations', 'bookingCount', 'reservas']),
+      revenue: readCurrency(reportTotals, ['revenue', 'totalRevenue', 'receita', 'grossRevenue', 'netRevenue']),
+    };
+
+    const mismatches = Object.entries(normalizedReports)
+      .filter(([key, value]) => value != null && !numbersRoughlyEqual(value, metrics[key]));
+
+    if (mismatches.length === 0) {
+      const reference = reportTotals.generatedAt || payload?.lastReportSync || payload?.reports?.generatedAt;
+      metricsValidation.textContent = reference
+        ? `Números reconciliados com os relatórios (${formatDateTime(reference)}).`
+        : 'Números reconciliados com os relatórios.';
+      metricsValidation.classList.remove('text-red-600', 'text-amber-600', 'text-gray-500');
+      metricsValidation.classList.add('text-emerald-600');
+    } else {
+      const labels = mismatches.map(([key]) => METRIC_LABELS[key] || key);
+      metricsValidation.textContent = `Diferenças encontradas nos relatórios: ${labels.join(', ')}.`;
+      metricsValidation.classList.remove('text-emerald-600', 'text-gray-500');
+      metricsValidation.classList.add('text-red-600');
+    }
+  }
+
+  function renderEvents(events) {
+    if (!eventsList) return;
+    eventsList.innerHTML = '';
+    if (!events.length) return;
+
+    const fragment = document.createDocumentFragment();
+    events.forEach((event) => {
+      const item = document.createElement('li');
+      item.className = 'p-5 flex flex-col md:flex-row md:items-start md:justify-between gap-4';
+
+      const left = document.createElement('div');
+      left.className = 'space-y-1';
+
+      const title = document.createElement('p');
+      title.className = 'text-base font-semibold text-gray-900';
+      title.textContent = event.title || event.label || deriveEventTitle(event.type);
+      left.appendChild(title);
+
+      if (event.description) {
+        const description = document.createElement('p');
+        description.className = 'text-sm text-gray-600';
+        description.textContent = event.description;
+        left.appendChild(description);
+      }
+
+      if (event.actor) {
+        const actor = document.createElement('p');
+        actor.className = 'text-xs text-gray-400';
+        actor.textContent = `Por ${event.actor}`;
+        left.appendChild(actor);
+      }
+
+      const right = document.createElement('div');
+      right.className = 'text-right space-y-2 min-w-[120px]';
+
+      const badge = document.createElement('span');
+      badge.className = `inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-full ${badgeClassForEvent(event.severity || event.type)}`;
+      badge.textContent = (event.type || 'EVENTO').toUpperCase();
+      right.appendChild(badge);
+
+      const time = document.createElement('time');
+      time.className = 'block text-sm text-gray-500';
+      time.dateTime = event.timestamp;
+      time.textContent = formatDateTime(event.timestamp);
+      right.appendChild(time);
+
+      item.appendChild(left);
+      item.appendChild(right);
+
+      fragment.appendChild(item);
+    });
+
+    eventsList.appendChild(fragment);
+  }
+
+  function setupQuickActions() {
+    const modal = document.getElementById('quickActionModal');
+    const modalTitle = document.getElementById('quickActionModalTitle');
+    const modalFields = document.getElementById('quickActionFields');
+    const modalFeedback = document.getElementById('quickActionFeedback');
+    const modalForm = document.getElementById('quickActionForm');
+    const modalClose = document.getElementById('quickActionModalClose');
+    const modalCancel = document.getElementById('quickActionCancel');
+    const modalSubmit = document.getElementById('quickActionSubmit');
+
+    if (!modal || !modalForm) return;
+
+    const quickActionConfig = {
+      trail: {
+        title: 'Cadastrar nova trilha',
+        endpoint: DASHBOARD_ENDPOINTS.quickActions.trail,
+        successMessage: 'Trilha cadastrada com sucesso!',
+        fields: [
+          { name: 'name', label: 'Nome da trilha', type: 'text', placeholder: 'Ex: Travessia da Serra do Mar', required: true },
+          { name: 'state', label: 'Estado/UF', type: 'text', placeholder: 'Ex: SP', maxLength: 2, required: true, transform: (value) => value?.toUpperCase() },
+          { name: 'difficulty', label: 'Dificuldade', type: 'select', required: true, options: ['Fácil', 'Moderada', 'Difícil', 'Muito difícil'] },
+        ],
+        transformPayload(payload) {
+          return {
+            name: payload.name,
+            state: payload.state,
+            difficulty: payload.difficulty,
+            status: 'ACTIVE',
+          };
+        },
+      },
+      expedition: {
+        title: 'Nova expedição',
+        endpoint: DASHBOARD_ENDPOINTS.quickActions.expedition,
+        successMessage: 'Expedição criada com sucesso!',
+        fields: [
+          { name: 'title', label: 'Nome da expedição', type: 'text', placeholder: 'Ex: Expedição Monte Roraima', required: true },
+          { name: 'startDate', label: 'Data de início', type: 'date', required: true },
+          { name: 'vacancies', label: 'Vagas', type: 'number', min: 1, max: 50, required: true },
+          { name: 'guide', label: 'Guia responsável', type: 'text', placeholder: 'Ex: Maria Silva', required: true },
+        ],
+        transformPayload(payload) {
+          return {
+            title: payload.title,
+            startDate: payload.startDate,
+            vacancies: Number(payload.vacancies),
+            guide: payload.guide,
+            status: 'PLANNED',
+          };
+        },
+      },
+      post: {
+        title: 'Novo post no blog',
+        endpoint: DASHBOARD_ENDPOINTS.quickActions.post,
+        successMessage: 'Post criado e enviado para revisão!',
+        fields: [
+          { name: 'title', label: 'Título', type: 'text', placeholder: 'Ex: Guia completo da Serra Fina', required: true },
+          { name: 'slug', label: 'Slug', type: 'text', placeholder: 'ex: guia-completo-serra-fina', required: true },
+          { name: 'status', label: 'Status', type: 'select', options: ['rascunho', 'revisao', 'publicado'], required: true },
+        ],
+        transformPayload(payload) {
+          return {
+            title: payload.title,
+            slug: payload.slug,
+            status: payload.status,
+          };
+        },
+      },
+    };
+
+    let currentAction = null;
+
+    function openModal(actionKey) {
+      const config = quickActionConfig[actionKey];
+      if (!config) return;
+      currentAction = config;
+      modalTitle.textContent = config.title;
+      renderActionFields(config.fields, modalFields);
+      modalForm.reset();
+      if (modalFeedback) {
+        modalFeedback.className = 'text-sm hidden';
+        modalFeedback.textContent = '';
+      }
+      modalSubmit.textContent = config.submitLabel || 'Salvar';
+      modal.classList.remove('hidden');
+      modal.classList.add('flex');
+      document.body.classList.add('overflow-hidden');
+    }
+
+    function closeModal() {
+      modal.classList.add('hidden');
+      modal.classList.remove('flex');
+      document.body.classList.remove('overflow-hidden');
+      currentAction = null;
+    }
+
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        closeModal();
+      }
+    });
+
+    modalClose?.addEventListener('click', closeModal);
+    modalCancel?.addEventListener('click', closeModal);
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !modal.classList.contains('hidden')) {
+        closeModal();
+      }
+    });
+
+    modalForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!currentAction) return;
+      modalSubmit.disabled = true;
+      modalSubmit.classList.add('opacity-60');
+      if (modalFeedback) {
+        modalFeedback.textContent = 'Enviando...';
+        modalFeedback.className = 'text-sm text-gray-500';
+      }
+
+      const formData = new FormData(modalForm);
+      const payload = {};
+      currentAction.fields.forEach((field) => {
+        const raw = formData.get(field.name);
+        if (field.transform && typeof field.transform === 'function') {
+          payload[field.name] = field.transform(raw);
+        } else {
+          payload[field.name] = raw;
+        }
+      });
+      const finalPayload = currentAction.transformPayload
+        ? currentAction.transformPayload(payload)
+        : payload;
+
+      try {
+        const response = await fetchWithTimeout(
+          currentAction.endpoint,
+          {
+            method: currentAction.method || 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(finalPayload),
+          },
+          currentAction.timeout || DASHBOARD_TIMEOUT,
+        );
+        if (!response.ok) {
+          throw new Error(`Falha ao enviar dados (${response.status})`);
+        }
+        const result = await parseJsonSafely(response);
+        if (modalFeedback) {
+          modalFeedback.textContent = result?.message || currentAction.successMessage || 'Operação concluída com sucesso.';
+          modalFeedback.className = 'text-sm text-emerald-600';
+        }
+        setTimeout(() => {
+          closeModal();
+          loadMetrics();
+          if (currentAction.refreshEvents) {
+            loadEvents();
+          }
+        }, currentAction.closeDelay || 1200);
+      } catch (error) {
+        console.error('Erro ao executar ação rápida', error);
+        if (modalFeedback) {
+          modalFeedback.textContent = currentAction.errorMessage || 'Não foi possível concluir a operação. Tente novamente.';
+          modalFeedback.className = 'text-sm text-red-600';
+        }
+      } finally {
+        modalSubmit.disabled = false;
+        modalSubmit.classList.remove('opacity-60');
+      }
+    });
+
+    document.querySelectorAll('[data-quick-action]').forEach((button) => {
+      const actionKey = button.getAttribute('data-quick-action');
+      button.addEventListener('click', () => openModal(actionKey));
+    });
+  }
+
+  refreshButton?.addEventListener('click', async () => {
+    setRefreshInProgress(true);
+    await Promise.all([loadMetrics(), loadEvents()]).catch(() => {});
+    setRefreshInProgress(false);
+  });
+
+  loadMetrics();
+  loadEvents();
+  setupQuickActions();
+});
+
+function fetchWithTimeout(url, options = {}, timeout = DASHBOARD_TIMEOUT) {
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  return fetch(url, { ...options, signal })
+    .finally(() => clearTimeout(timer));
+}
+
+async function parseJsonSafely(response) {
+  try {
+    const clone = response.clone();
+    const text = await clone.text();
+    if (!text) return {};
+    return JSON.parse(text);
+  } catch (error) {
+    return {};
+  }
+}
+
+function normalizeMetrics(payload) {
+  const source = payload?.metrics || payload?.data || payload?.totals || payload || {};
+  return {
+    trails: readFirstNumber(source, ['trails', 'totalTrails', 'trailCount', 'trilhas']),
+    expeditions: readFirstNumber(source, ['expeditions', 'totalExpeditions', 'expeditionCount', 'expedicoes']),
+    activeGuides: readFirstNumber(source, ['activeGuides', 'guides', 'totalGuides', 'guiaAtivos']),
+    reservations: readFirstNumber(source, ['reservations', 'totalReservations', 'bookingCount', 'reservas']),
+    revenue: readCurrency(source, ['revenue', 'totalRevenue', 'receita', 'grossRevenue', 'netRevenue']),
+  };
+}
+
+function normalizeEvents(payload) {
+  const events = payload?.events || payload?.data || payload?.items || [];
+  return events
+    .map((event) => ({
+      id: event.id || event.eventId || null,
+      type: event.type || event.category || 'evento',
+      title: event.title || event.label || '',
+      description: event.description || event.details || event.message || '',
+      actor: event.actor || event.user || event.performedBy || '',
+      timestamp: event.timestamp || event.occurredAt || event.date || event.createdAt || new Date().toISOString(),
+      severity: event.severity || event.level || null,
+    }))
+    .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+    .slice(0, 8);
+}
+
+function renderActionFields(fields, container) {
+  if (!container) return;
+  container.innerHTML = '';
+  fields.forEach((field) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'space-y-1';
+
+    const label = document.createElement('label');
+    label.className = 'block text-sm font-medium text-gray-700';
+    const inputId = `quick-${field.name}`;
+    label.setAttribute('for', inputId);
+    label.textContent = field.label;
+
+    let input;
+    if (field.type === 'select') {
+      input = document.createElement('select');
+      input.className = 'mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500';
+      (field.options || []).forEach((option) => {
+        const optionEl = document.createElement('option');
+        optionEl.value = option;
+        optionEl.textContent = option.charAt(0).toUpperCase() + option.slice(1);
+        input.appendChild(optionEl);
+      });
+    } else if (field.type === 'textarea') {
+      input = document.createElement('textarea');
+      input.rows = field.rows || 4;
+      input.className = 'mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500';
+    } else {
+      input = document.createElement('input');
+      input.type = field.type || 'text';
+      input.className = 'mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500';
+      if (field.type === 'number' && typeof field.min !== 'undefined') input.min = field.min;
+      if (field.type === 'number' && typeof field.max !== 'undefined') input.max = field.max;
+      if (field.maxLength) input.maxLength = field.maxLength;
+    }
+
+    input.name = field.name;
+    input.id = inputId;
+    if (field.placeholder) input.placeholder = field.placeholder;
+    if (field.required) input.required = true;
+
+    wrapper.appendChild(label);
+    wrapper.appendChild(input);
+
+    if (field.helper) {
+      const helper = document.createElement('p');
+      helper.className = 'text-xs text-gray-400';
+      helper.textContent = field.helper;
+      wrapper.appendChild(helper);
+    }
+
+    container.appendChild(wrapper);
+  });
+}
+
+function readFromStorage(key) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch (error) {
+    console.warn('Não foi possível ler o armazenamento local', error);
+    return null;
+  }
+}
+
+function saveToStorage(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn('Não foi possível salvar no armazenamento local', error);
+  }
+}
+
+function readFirstNumber(source, keys) {
+  for (const key of keys) {
+    const value = source?.[key];
+    if (typeof value === 'number') return value;
+    if (typeof value === 'string' && value.trim() !== '') {
+      const parsed = Number(value.replace(/[^0-9,-]+/g, '').replace(',', '.'));
+      if (!Number.isNaN(parsed)) return parsed;
+    }
+  }
+  return 0;
+}
+
+function readCurrency(source, keys) {
+  for (const key of keys) {
+    const value = source?.[key];
+    if (typeof value === 'number') return value;
+    if (typeof value === 'string' && value.trim() !== '') {
+      const normalized = Number(value.replace(/[^0-9,-]+/g, '').replace(',', '.'));
+      if (!Number.isNaN(normalized)) return normalized;
+    }
+  }
+  return 0;
+}
+
+function numbersRoughlyEqual(a, b) {
+  const diff = Math.abs(Number(a || 0) - Number(b || 0));
+  return diff < 1e-6;
+}
+
+function setText(id, text) {
+  const element = document.getElementById(id);
+  if (element) {
+    element.textContent = text;
+  }
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('pt-BR').format(Number(value) || 0);
+}
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+  }).format(Number(value) || 0);
+}
+
+function formatDateTime(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+}
+
+function deriveEventTitle(type) {
+  if (!type) return 'Evento do sistema';
+  const normalized = type.toLowerCase();
+  if (normalized.includes('reserva')) return 'Reserva atualizada';
+  if (normalized.includes('pagamento')) return 'Pagamento processado';
+  if (normalized.includes('guia')) return 'Atualização de guia';
+  if (normalized.includes('expedi')) return 'Atualização de expedição';
+  if (normalized.includes('trilha')) return 'Atualização de trilha';
+  return 'Evento do sistema';
+}
+
+function badgeClassForEvent(type) {
+  if (!type) return 'bg-gray-100 text-gray-600';
+  const normalized = String(type).toLowerCase();
+  if (normalized.includes('erro') || normalized.includes('fail') || normalized.includes('critico')) {
+    return 'bg-red-100 text-red-600';
+  }
+  if (normalized.includes('alerta') || normalized.includes('warning')) {
+    return 'bg-amber-100 text-amber-600';
+  }
+  if (normalized.includes('sucesso') || normalized.includes('ok') || normalized.includes('confirm')) {
+    return 'bg-emerald-100 text-emerald-600';
+  }
+  return 'bg-gray-100 text-gray-600';
+}
+
+function hideElement(element) {
+  if (!element) return;
+  element.classList.add('hidden');
+}
+
+function showElement(element) {
+  if (!element) return;
+  element.classList.remove('hidden');
+}
+
+function toggleElement(element, shouldShow) {
+  if (!element) return;
+  element.classList.toggle('hidden', !shouldShow);
+}


### PR DESCRIPTION
## Summary
- replace the former Cadastur upload screen with a dashboard that highlights KPIs, quick creation shortcuts, and recent events
- add a dedicated admin-dashboard script to fetch metrics/events with caching, SLA feedback, and modal-based quick actions

## Testing
- not run (static frontend changes)


------
https://chatgpt.com/codex/tasks/task_e_68c83c2226108324af2910ec68e21afa