### PR TITLE
feat: add JWT cookie-based auth with refresh tokens

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -15,4 +15,5 @@ S3_ENDPOINT="https://<account>.r2.cloudflarestorage.com"
 # API configuration
 PORT=3000
 CORS_ORIGIN="http://localhost:3000"
+AUTH_COOKIE_DOMAIN=""
 COMMISSION_BPS_DEFAULT=500

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -12,3 +12,27 @@ model HealthCheck {
   createdAt DateTime @default(now())
   status    String   @default("ok")
 }
+
+model User {
+  id           String        @id @default(uuid())
+  email        String        @unique
+  passwordHash String
+  name         String?
+  role         String        @default("user")
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  sessions     AuthSession[]
+}
+
+model AuthSession {
+  id        String    @id @default(uuid())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  tokenHash String    @unique
+  expiresAt DateTime
+  createdAt DateTime  @default(now())
+  revokedAt DateTime?
+
+  @@index([userId])
+  @@index([expiresAt])
+}

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -8,6 +8,7 @@ import pinoHttp from 'pino-http';
 import { HttpError, errorHandler } from './middlewares/error';
 import { requestId } from './middlewares/request-id';
 import { prisma } from './services/prisma';
+import { authRouter } from './modules/auth/auth.routes';
 
 const logger = pino({
   level: process.env.LOG_LEVEL ?? 'info',
@@ -82,6 +83,8 @@ app.get('/api/healthz', async (_req: Request, res: Response, next: NextFunction)
     );
   }
 });
+
+app.use('/api/auth', authRouter);
 
 app.use(errorHandler);
 

--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -1,0 +1,51 @@
+import type { Request, RequestHandler } from 'express';
+
+import { HttpError } from './error';
+
+type RateLimitOptions = {
+  windowMs: number;
+  max: number;
+  keyGenerator?: (req: Request) => string;
+};
+
+type RateLimitEntry = {
+  count: number;
+  expiresAt: number;
+};
+
+const defaultKeyGenerator = (req: Request): string => {
+  return req.ip || req.headers['x-forwarded-for']?.toString() || req.socket.remoteAddress || 'unknown';
+};
+
+export const rateLimit = ({ windowMs, max, keyGenerator }: RateLimitOptions): RequestHandler => {
+  if (windowMs <= 0) {
+    throw new Error('windowMs must be greater than 0');
+  }
+  if (max <= 0) {
+    throw new Error('max must be greater than 0');
+  }
+
+  const hits = new Map<string, RateLimitEntry>();
+
+  return (req, _res, next) => {
+    const now = Date.now();
+    const key = keyGenerator ? keyGenerator(req) : defaultKeyGenerator(req);
+
+    const entry = hits.get(key);
+    if (!entry || entry.expiresAt <= now) {
+      hits.set(key, { count: 1, expiresAt: now + windowMs });
+      next();
+      return;
+    }
+
+    if (entry.count >= max) {
+      next(new HttpError(429, 'RATE_LIMIT_EXCEEDED', 'Too many requests'));
+      return;
+    }
+
+    entry.count += 1;
+    hits.set(key, entry);
+
+    next();
+  };
+};

--- a/api/src/modules/auth/auth.routes.ts
+++ b/api/src/modules/auth/auth.routes.ts
@@ -1,0 +1,141 @@
+import type { CookieOptions, Request, Response } from 'express';
+import { Router } from 'express';
+
+import { HttpError } from '../../middlewares/error';
+import { rateLimit } from '../../middlewares/rate-limit';
+import { validate } from '../../middlewares/validation';
+import {
+  ACCESS_TOKEN_EXPIRATION_SECONDS,
+  REFRESH_TOKEN_EXPIRATION_SECONDS,
+  authService,
+} from './auth.service';
+import { loginSchema, type LoginInput } from './auth.schemas';
+
+const ACCESS_TOKEN_COOKIE_NAME = 'accessToken';
+const REFRESH_TOKEN_COOKIE_NAME = 'refreshToken';
+const ACCESS_TOKEN_COOKIE_ALIASES = [ACCESS_TOKEN_COOKIE_NAME, 'access_token'] as const;
+const REFRESH_TOKEN_COOKIE_ALIASES = [REFRESH_TOKEN_COOKIE_NAME, 'refresh_token'] as const;
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const resolveCookieDomain = (): string | undefined => {
+  const domain = process.env.AUTH_COOKIE_DOMAIN ?? process.env.COOKIE_DOMAIN;
+  if (domain && domain.trim().length > 0) {
+    return domain.trim();
+  }
+  return undefined;
+};
+
+const baseCookieOptions = (): CookieOptions => {
+  const options: CookieOptions = {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    path: '/',
+  };
+
+  const domain = resolveCookieDomain();
+  if (domain) {
+    options.domain = domain;
+  }
+
+  return options;
+};
+
+const buildAccessCookieOptions = (): CookieOptions => ({
+  ...baseCookieOptions(),
+  maxAge: ACCESS_TOKEN_EXPIRATION_SECONDS * 1000,
+});
+
+const buildRefreshCookieOptions = (): CookieOptions => ({
+  ...baseCookieOptions(),
+  maxAge: REFRESH_TOKEN_EXPIRATION_SECONDS * 1000,
+});
+
+const getRefreshTokenFromRequest = (req: Request): string | undefined => {
+  for (const name of REFRESH_TOKEN_COOKIE_ALIASES) {
+    const token = req.cookies?.[name];
+    if (typeof token === 'string' && token.trim().length > 0) {
+      return token.trim();
+    }
+  }
+  return undefined;
+};
+
+const clearAuthCookies = (res: Response) => {
+  const options = baseCookieOptions();
+  for (const name of ACCESS_TOKEN_COOKIE_ALIASES) {
+    res.clearCookie(name, options);
+  }
+  for (const name of REFRESH_TOKEN_COOKIE_ALIASES) {
+    res.clearCookie(name, options);
+  }
+};
+
+const setAuthCookies = (res: Response, tokens: { accessToken: string; refreshToken: string }) => {
+  res.cookie(ACCESS_TOKEN_COOKIE_NAME, tokens.accessToken, buildAccessCookieOptions());
+  res.cookie(REFRESH_TOKEN_COOKIE_NAME, tokens.refreshToken, buildRefreshCookieOptions());
+};
+
+const router = Router();
+
+const authRateLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 10,
+});
+
+router.use(authRateLimiter);
+
+router.post('/login', validate(loginSchema), async (req, res, next) => {
+  const { email, password } = req.body as LoginInput;
+
+  try {
+    const { user, accessToken, refreshToken } = await authService.login(email, password);
+
+    setAuthCookies(res, { accessToken, refreshToken });
+
+    res.status(200).json({
+      user,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/refresh', async (req, res, next) => {
+  const refreshToken = getRefreshTokenFromRequest(req);
+
+  if (!refreshToken) {
+    next(new HttpError(401, 'REFRESH_TOKEN_MISSING', 'Refresh token is missing'));
+    return;
+  }
+
+  try {
+    const { user, accessToken, refreshToken: newRefreshToken } = await authService.refresh(refreshToken);
+
+    setAuthCookies(res, { accessToken, refreshToken: newRefreshToken });
+
+    res.status(200).json({
+      user,
+    });
+  } catch (error) {
+    clearAuthCookies(res);
+    next(error);
+  }
+});
+
+router.post('/logout', async (req, res, next) => {
+  const refreshToken = getRefreshTokenFromRequest(req);
+
+  try {
+    await authService.logout(refreshToken);
+  } catch (error) {
+    next(error);
+    return;
+  }
+
+  clearAuthCookies(res);
+  res.status(204).send();
+});
+
+export const authRouter = router;

--- a/api/src/modules/auth/auth.schemas.ts
+++ b/api/src/modules/auth/auth.schemas.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  body: z.object({
+    email: z.string().email('E-mail inválido'),
+    password: z.string().min(8, 'A senha deve conter pelo menos 8 caracteres').max(72),
+  }),
+});
+
+export type LoginInput = z.infer<typeof loginSchema>['body'];

--- a/api/src/modules/auth/auth.service.ts
+++ b/api/src/modules/auth/auth.service.ts
@@ -1,0 +1,217 @@
+import type { User } from '@prisma/client';
+import bcrypt from 'bcrypt';
+import { createHash, randomUUID } from 'crypto';
+import jwt from 'jsonwebtoken';
+
+import { HttpError } from '../../middlewares/error';
+import { prisma, type PrismaClientInstance } from '../../services/prisma';
+
+export const ACCESS_TOKEN_EXPIRATION_SECONDS = 15 * 60; // 15 minutes
+export const REFRESH_TOKEN_EXPIRATION_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+export type BasicUserProfile = {
+  id: string;
+  email: string;
+  name: string | null;
+  role: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type RefreshTokenPayload = jwt.JwtPayload & {
+  sub: string;
+  sid: string;
+  type: 'refresh';
+};
+
+type LoginResult = {
+  user: BasicUserProfile;
+  accessToken: string;
+  refreshToken: string;
+};
+
+const hashToken = (token: string): string => {
+  return createHash('sha256').update(token).digest('hex');
+};
+
+const toBasicProfile = (user: User): BasicUserProfile => ({
+  id: user.id,
+  email: user.email,
+  name: user.name,
+  role: user.role,
+  createdAt: user.createdAt.toISOString(),
+  updatedAt: user.updatedAt.toISOString(),
+});
+
+const getAccessSecret = (): string => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new HttpError(500, 'JWT_SECRET_NOT_CONFIGURED', 'JWT secret is not configured');
+  }
+  return secret;
+};
+
+const getRefreshSecret = (): string => {
+  const secret = process.env.REFRESH_SECRET ?? process.env.JWT_SECRET;
+  if (!secret) {
+    throw new HttpError(500, 'REFRESH_SECRET_NOT_CONFIGURED', 'Refresh token secret is not configured');
+  }
+  return secret;
+};
+
+export class AuthService {
+  constructor(private readonly prismaClient: PrismaClientInstance = prisma) {}
+
+  private signAccessToken(user: User): string {
+    const payload: jwt.JwtPayload & {
+      sub: string;
+      email: string;
+      name?: string;
+      roles: string[];
+      type: 'access';
+    } = {
+      sub: user.id,
+      email: user.email,
+      name: user.name ?? undefined,
+      roles: [user.role],
+      type: 'access',
+    };
+
+    return jwt.sign(payload, getAccessSecret(), {
+      expiresIn: ACCESS_TOKEN_EXPIRATION_SECONDS,
+    });
+  }
+
+  private async createSession(userId: string): Promise<string> {
+    const sessionId = randomUUID();
+    const expiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRATION_SECONDS * 1000);
+    const tokenHash = hashToken(sessionId);
+
+    await this.prismaClient.authSession.create({
+      data: {
+        userId,
+        tokenHash,
+        expiresAt,
+      },
+    });
+
+    const refreshPayload: RefreshTokenPayload = {
+      sub: userId,
+      sid: sessionId,
+      type: 'refresh',
+    };
+
+    const refreshToken = jwt.sign(refreshPayload, getRefreshSecret(), {
+      expiresIn: REFRESH_TOKEN_EXPIRATION_SECONDS,
+    });
+
+    return refreshToken;
+  }
+
+  private verifyRefreshToken(refreshToken: string): RefreshTokenPayload {
+    try {
+      const decoded = jwt.verify(refreshToken, getRefreshSecret()) as RefreshTokenPayload;
+
+      if (typeof decoded.sub !== 'string' || typeof decoded.sid !== 'string' || decoded.type !== 'refresh') {
+        throw new Error('Invalid refresh token payload');
+      }
+
+      return decoded;
+    } catch (error) {
+      throw new HttpError(
+        401,
+        'INVALID_REFRESH_TOKEN',
+        'Invalid refresh token',
+        error instanceof Error ? error.message : undefined,
+      );
+    }
+  }
+
+  async login(email: string, password: string): Promise<LoginResult> {
+    const user = await this.prismaClient.user.findUnique({
+      where: { email },
+    });
+
+    if (!user) {
+      throw new HttpError(401, 'INVALID_CREDENTIALS', 'Invalid email or password');
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+
+    if (!isPasswordValid) {
+      throw new HttpError(401, 'INVALID_CREDENTIALS', 'Invalid email or password');
+    }
+
+    const accessToken = this.signAccessToken(user);
+    const refreshToken = await this.createSession(user.id);
+
+    return {
+      user: toBasicProfile(user),
+      accessToken,
+      refreshToken,
+    };
+  }
+
+  async refresh(refreshToken: string): Promise<LoginResult> {
+    const payload = this.verifyRefreshToken(refreshToken);
+    const now = new Date();
+    const hashedToken = hashToken(payload.sid);
+
+    const session = await this.prismaClient.authSession.findUnique({
+      where: { tokenHash: hashedToken },
+      include: { user: true },
+    });
+
+    if (!session || !session.user || session.userId !== payload.sub) {
+      throw new HttpError(401, 'INVALID_REFRESH_TOKEN', 'Invalid refresh token');
+    }
+
+    if (session.revokedAt) {
+      throw new HttpError(401, 'INVALID_REFRESH_TOKEN', 'Refresh token has been revoked');
+    }
+
+    if (session.expiresAt.getTime() <= now.getTime()) {
+      await this.prismaClient.authSession.update({
+        where: { id: session.id },
+        data: { revokedAt: now },
+      }).catch(() => undefined);
+      throw new HttpError(401, 'REFRESH_TOKEN_EXPIRED', 'Refresh token has expired');
+    }
+
+    await this.prismaClient.authSession.update({
+      where: { id: session.id },
+      data: { revokedAt: now },
+    });
+
+    const newRefreshToken = await this.createSession(session.userId);
+    const accessToken = this.signAccessToken(session.user);
+
+    return {
+      user: toBasicProfile(session.user),
+      accessToken,
+      refreshToken: newRefreshToken,
+    };
+  }
+
+  async logout(refreshToken: string | undefined): Promise<void> {
+    if (!refreshToken) {
+      return;
+    }
+
+    try {
+      const payload = this.verifyRefreshToken(refreshToken);
+      const hashedToken = hashToken(payload.sid);
+
+      await this.prismaClient.authSession.updateMany({
+        where: { tokenHash: hashedToken, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+    } catch (error) {
+      if (error instanceof HttpError && error.statusCode >= 500) {
+        throw error;
+      }
+    }
+  }
+}
+
+export const authService = new AuthService();


### PR DESCRIPTION
## Summary
- extend the Prisma schema with user and auth session models to store credentials and refresh token state
- add an auth service plus login/refresh/logout routes that issue HttpOnly cookies with JWT access and refresh tokens
- introduce an in-memory rate limiter for auth endpoints and register the auth router in the main Express app

## Testing
- npm run build *(fails: missing npm dependencies because the registry returned 403 errors in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc822665b48324af86d44c7af14f9e