### PR TITLE
Add admin geo endpoints for states, cities, and parks

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -24,6 +24,14 @@ enum GuideVerificationStatus {
   REJECTED
 }
 
+enum Region {
+  NORTH
+  NORTHEAST
+  CENTRAL_WEST
+  SOUTHEAST
+  SOUTH
+}
+
 model User {
   id           String        @id @default(uuid())
   email        String        @unique
@@ -89,4 +97,51 @@ model GuideProfile {
   updatedAt                DateTime                @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model State {
+  id        Int      @id @default(autoincrement())
+  code      String   @unique
+  name      String
+  region    Region
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  cities City[]
+
+  @@index([name])
+  @@index([region])
+}
+
+model City {
+  id        Int      @id @default(autoincrement())
+  stateId   Int
+  name      String
+  slug      String
+  isCapital Boolean  @default(false)
+  latitude  Decimal? @db.Decimal(10, 7)
+  longitude Decimal? @db.Decimal(10, 7)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  state State @relation(fields: [stateId], references: [id])
+  parks Park[]
+
+  @@unique([stateId, slug])
+  @@index([stateId, name])
+}
+
+model Park {
+  id          Int      @id @default(autoincrement())
+  cityId      Int
+  name        String
+  slug        String
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  city City @relation(fields: [cityId], references: [id])
+
+  @@unique([cityId, slug])
+  @@index([cityId, name])
 }

--- a/api/src/modules/admin/admin.routes.ts
+++ b/api/src/modules/admin/admin.routes.ts
@@ -7,6 +7,9 @@ import { HttpError } from '../../middlewares/error';
 import { requireRole } from '../../middlewares/rbac';
 import { audit } from '../audit/audit.service';
 import { adminGuidesRouter } from '../guides/admin-guides.routes';
+import { adminCitiesRouter } from '../geo/admin-cities.routes';
+import { adminParksRouter } from '../geo/admin-parks.routes';
+import { adminStatesRouter } from '../geo/admin-states.routes';
 import { adminUsersRouter } from '../users/admin-users.routes';
 
 const router = Router();
@@ -29,6 +32,9 @@ const parseBooleanFlag = (value: unknown): boolean => {
 
 router.use('/users', adminUsersRouter);
 router.use('/guides', adminGuidesRouter);
+router.use('/states', adminStatesRouter);
+router.use('/cities', adminCitiesRouter);
+router.use('/parks', adminParksRouter);
 
 router.post(
   '/cadastur/import',

--- a/api/src/modules/geo/admin-cities.routes.ts
+++ b/api/src/modules/geo/admin-cities.routes.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+
+import { requireRole } from '../../middlewares/rbac';
+import { validate } from '../../middlewares/validation';
+import { adminGeoService } from './geo.service';
+import { createCitySchema, listCitiesSchema, type CreateCityBody, type ListCitiesQuery } from './geo.schemas';
+
+const router = Router();
+
+const getActorRoles = (roles: unknown): string[] => {
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+
+  return roles
+    .map((role) => (typeof role === 'string' ? role.trim() : ''))
+    .filter((role) => role.length > 0);
+};
+
+router.get(
+  '/',
+  requireRole('ADMIN', 'EDITOR', 'OPERADOR'),
+  validate(listCitiesSchema),
+  async (req, res, next) => {
+    try {
+      const query = req.query as unknown as ListCitiesQuery;
+      const cities = await adminGeoService.listCities(query);
+
+      res.status(200).json({ cities });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/',
+  requireRole('ADMIN', 'EDITOR'),
+  validate(createCitySchema),
+  async (req, res, next) => {
+    try {
+      const body = req.body as CreateCityBody;
+      const actorRoles = getActorRoles(req.user?.roles);
+      const city = await adminGeoService.createCity(
+        { actorId: req.user?.sub, roles: actorRoles },
+        body,
+        { ip: req.ip, userAgent: req.get('user-agent') },
+      );
+
+      res.status(201).json({ city });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export const adminCitiesRouter = router;

--- a/api/src/modules/geo/admin-parks.routes.ts
+++ b/api/src/modules/geo/admin-parks.routes.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+
+import { requireRole } from '../../middlewares/rbac';
+import { validate } from '../../middlewares/validation';
+import { adminGeoService } from './geo.service';
+import { createParkSchema, listParksSchema, type CreateParkBody, type ListParksQuery } from './geo.schemas';
+
+const router = Router();
+
+const getActorRoles = (roles: unknown): string[] => {
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+
+  return roles
+    .map((role) => (typeof role === 'string' ? role.trim() : ''))
+    .filter((role) => role.length > 0);
+};
+
+router.get(
+  '/',
+  requireRole('ADMIN', 'EDITOR', 'OPERADOR'),
+  validate(listParksSchema),
+  async (req, res, next) => {
+    try {
+      const query = req.query as unknown as ListParksQuery;
+      const parks = await adminGeoService.listParks(query);
+
+      res.status(200).json({ parks });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/',
+  requireRole('ADMIN', 'EDITOR'),
+  validate(createParkSchema),
+  async (req, res, next) => {
+    try {
+      const body = req.body as CreateParkBody;
+      const actorRoles = getActorRoles(req.user?.roles);
+      const park = await adminGeoService.createPark(
+        { actorId: req.user?.sub, roles: actorRoles },
+        body,
+        { ip: req.ip, userAgent: req.get('user-agent') },
+      );
+
+      res.status(201).json({ park });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export const adminParksRouter = router;

--- a/api/src/modules/geo/admin-states.routes.ts
+++ b/api/src/modules/geo/admin-states.routes.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+
+import { requireRole } from '../../middlewares/rbac';
+import { validate } from '../../middlewares/validation';
+import { adminGeoService } from './geo.service';
+import { createStateSchema, listStatesSchema, type CreateStateBody, type ListStatesQuery } from './geo.schemas';
+
+const router = Router();
+
+const getActorRoles = (roles: unknown): string[] => {
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+
+  return roles
+    .map((role) => (typeof role === 'string' ? role.trim() : ''))
+    .filter((role) => role.length > 0);
+};
+
+router.get(
+  '/',
+  requireRole('ADMIN', 'EDITOR', 'OPERADOR'),
+  validate(listStatesSchema),
+  async (req, res, next) => {
+    try {
+      const query = req.query as unknown as ListStatesQuery;
+      const states = await adminGeoService.listStates(query);
+
+      res.status(200).json({ states });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/',
+  requireRole('ADMIN', 'EDITOR'),
+  validate(createStateSchema),
+  async (req, res, next) => {
+    try {
+      const body = req.body as CreateStateBody;
+      const actorRoles = getActorRoles(req.user?.roles);
+      const state = await adminGeoService.createState(
+        { actorId: req.user?.sub, roles: actorRoles },
+        body,
+        { ip: req.ip, userAgent: req.get('user-agent') },
+      );
+
+      res.status(201).json({ state });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export const adminStatesRouter = router;

--- a/api/src/modules/geo/geo.schemas.ts
+++ b/api/src/modules/geo/geo.schemas.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+
+export const REGION_VALUES = ['NORTH', 'NORTHEAST', 'CENTRAL_WEST', 'SOUTHEAST', 'SOUTH'] as const;
+
+const nameSchema = z
+  .string()
+  .trim()
+  .min(1, { message: 'Name is required' })
+  .max(255, { message: 'Name must be at most 255 characters long' });
+
+const searchSchema = z
+  .string()
+  .trim()
+  .min(1, { message: 'Search term must contain at least 1 character' })
+  .max(255, { message: 'Search term must be at most 255 characters long' });
+
+const slugInputSchema = z
+  .string()
+  .trim()
+  .min(1, { message: 'Slug is required when provided' })
+  .max(255, { message: 'Slug must be at most 255 characters long' });
+
+const ufSchema = z
+  .string()
+  .trim()
+  .length(2, { message: 'State code must have exactly 2 characters' })
+  .regex(/^[a-zA-Z]{2}$/u, { message: 'State code must contain only letters' })
+  .transform((value) => value.toUpperCase());
+
+const latitudeSchema = z.coerce
+  .number()
+  .min(-90, { message: 'Latitude must be greater than or equal to -90' })
+  .max(90, { message: 'Latitude must be less than or equal to 90' });
+
+const longitudeSchema = z.coerce
+  .number()
+  .min(-180, { message: 'Longitude must be greater than or equal to -180' })
+  .max(180, { message: 'Longitude must be less than or equal to 180' });
+
+export const listStatesSchema = {
+  query: z
+    .object({
+      search: searchSchema.optional(),
+      region: z.enum(REGION_VALUES).optional(),
+    })
+    .strict(),
+};
+
+export type ListStatesQuery = z.infer<typeof listStatesSchema.query>;
+
+export const createStateSchema = {
+  body: z
+    .object({
+      code: ufSchema,
+      name: nameSchema,
+      region: z.enum(REGION_VALUES),
+    })
+    .strict(),
+};
+
+export type CreateStateBody = z.infer<typeof createStateSchema.body>;
+
+export const listCitiesSchema = {
+  query: z
+    .object({
+      state: ufSchema.optional(),
+      search: searchSchema.optional(),
+    })
+    .strict(),
+};
+
+export type ListCitiesQuery = z.infer<typeof listCitiesSchema.query>;
+
+export const createCitySchema = {
+  body: z
+    .object({
+      stateId: z.coerce.number().int().positive(),
+      name: nameSchema,
+      slug: slugInputSchema.optional(),
+      isCapital: z.boolean().optional(),
+      latitude: latitudeSchema.optional(),
+      longitude: longitudeSchema.optional(),
+    })
+    .strict()
+    .superRefine((data, ctx) => {
+      if ((data.latitude !== undefined && data.longitude === undefined) || (data.latitude === undefined && data.longitude !== undefined)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Latitude and longitude must be provided together',
+          path: data.latitude === undefined ? ['latitude'] : ['longitude'],
+        });
+      }
+    }),
+};
+
+export type CreateCityBody = z.infer<typeof createCitySchema.body>;
+
+export const listParksSchema = {
+  query: z
+    .object({
+      cityId: z.coerce.number().int().positive().optional(),
+      search: searchSchema.optional(),
+    })
+    .strict(),
+};
+
+export type ListParksQuery = z.infer<typeof listParksSchema.query>;
+
+export const createParkSchema = {
+  body: z
+    .object({
+      cityId: z.coerce.number().int().positive(),
+      name: nameSchema,
+      slug: slugInputSchema.optional(),
+      description: z
+        .string()
+        .trim()
+        .min(1, { message: 'Description must not be empty when provided' })
+        .max(1000, { message: 'Description must be at most 1000 characters long' })
+        .optional(),
+    })
+    .strict(),
+};
+
+export type CreateParkBody = z.infer<typeof createParkSchema.body>;

--- a/api/src/modules/geo/geo.service.ts
+++ b/api/src/modules/geo/geo.service.ts
@@ -1,0 +1,402 @@
+import { Prisma, type City, type Park, type State } from '@prisma/client';
+
+import { HttpError } from '../../middlewares/error';
+import { prisma, type PrismaClientInstance } from '../../services/prisma';
+import { audit } from '../audit/audit.service';
+import type {
+  CreateCityBody,
+  CreateParkBody,
+  CreateStateBody,
+  ListCitiesQuery,
+  ListParksQuery,
+  ListStatesQuery,
+} from './geo.schemas';
+
+export type ActorContext = {
+  actorId?: string | null;
+  roles: string[];
+};
+
+export type RequestContext = {
+  ip?: string | null;
+  userAgent?: string | null;
+};
+
+export type StateSummary = {
+  id: number;
+  code: string;
+  name: string;
+  region: State['region'];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type StateReference = Pick<StateSummary, 'id' | 'code' | 'name' | 'region'>;
+
+export type CitySummary = {
+  id: number;
+  stateId: number;
+  name: string;
+  slug: string;
+  isCapital: boolean;
+  latitude: number | null;
+  longitude: number | null;
+  createdAt: string;
+  updatedAt: string;
+  state: StateReference;
+};
+
+export type CityReference = Pick<CitySummary, 'id' | 'name' | 'slug' | 'isCapital' | 'state' | 'stateId'>;
+
+export type ParkSummary = {
+  id: number;
+  cityId: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+  city: CityReference;
+};
+
+const decimalToNumber = (value: Prisma.Decimal | null | undefined): number | null => {
+  if (!value) {
+    return null;
+  }
+
+  return value.toNumber();
+};
+
+const toStateSummary = (state: State): StateSummary => ({
+  id: state.id,
+  code: state.code,
+  name: state.name,
+  region: state.region,
+  createdAt: state.createdAt.toISOString(),
+  updatedAt: state.updatedAt.toISOString(),
+});
+
+const toStateReference = (state: State): StateReference => ({
+  id: state.id,
+  code: state.code,
+  name: state.name,
+  region: state.region,
+});
+
+const toCitySummary = (city: City & { state: State }): CitySummary => ({
+  id: city.id,
+  stateId: city.stateId,
+  name: city.name,
+  slug: city.slug,
+  isCapital: city.isCapital,
+  latitude: decimalToNumber(city.latitude),
+  longitude: decimalToNumber(city.longitude),
+  createdAt: city.createdAt.toISOString(),
+  updatedAt: city.updatedAt.toISOString(),
+  state: toStateReference(city.state),
+});
+
+const toCityReference = (city: City & { state: State }): CityReference => ({
+  id: city.id,
+  stateId: city.stateId,
+  name: city.name,
+  slug: city.slug,
+  isCapital: city.isCapital,
+  state: toStateReference(city.state),
+});
+
+const toParkSummary = (park: Park & { city: City & { state: State } }): ParkSummary => ({
+  id: park.id,
+  cityId: park.cityId,
+  name: park.name,
+  slug: park.slug,
+  description: park.description ?? null,
+  createdAt: park.createdAt.toISOString(),
+  updatedAt: park.updatedAt.toISOString(),
+  city: toCityReference(park.city),
+});
+
+const normalizeSearch = (value?: string): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const slugify = (input: string): string => {
+  const normalized = input
+    .normalize('NFD')
+    .replace(/[^\p{Letter}\p{Number}\s-]+/gu, '')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+
+  const slug = normalized
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+
+  return slug;
+};
+
+const ensureSlug = (input: string, entity: 'city' | 'park'): string => {
+  const slug = slugify(input);
+
+  if (slug.length === 0) {
+    throw new HttpError(400, 'INVALID_SLUG', `Unable to derive a valid slug for the ${entity}`);
+  }
+
+  return slug;
+};
+
+const normalizeRoles = (roles: string[]): Set<string> => {
+  return new Set(roles.map((role) => role.trim().toUpperCase()).filter((role) => role.length > 0));
+};
+
+export class AdminGeoService {
+  constructor(private readonly prismaClient: PrismaClientInstance = prisma) {}
+
+  async listStates(params: ListStatesQuery): Promise<StateSummary[]> {
+    const where: Prisma.StateWhereInput = {};
+    const search = normalizeSearch(params.search);
+
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { code: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    if (params.region) {
+      where.region = params.region;
+    }
+
+    const states = await this.prismaClient.state.findMany({
+      where,
+      orderBy: [{ name: 'asc' }],
+    });
+
+    return states.map(toStateSummary);
+  }
+
+  async createState(actor: ActorContext, input: CreateStateBody, context: RequestContext): Promise<StateSummary> {
+    const roles = normalizeRoles(actor.roles);
+
+    if (!(roles.has('ADMIN') || roles.has('EDITOR'))) {
+      throw new HttpError(403, 'INSUFFICIENT_ROLE', 'User lacks required role');
+    }
+
+    const code = input.code.trim().toUpperCase();
+    const name = input.name.trim();
+
+    const existingByCode = await this.prismaClient.state.findUnique({ where: { code } });
+    if (existingByCode) {
+      throw new HttpError(409, 'STATE_ALREADY_EXISTS', 'State with this code already exists');
+    }
+
+    const existingByName = await this.prismaClient.state.findFirst({
+      where: {
+        name: { equals: name, mode: 'insensitive' },
+      },
+    });
+
+    if (existingByName) {
+      throw new HttpError(409, 'STATE_ALREADY_EXISTS', 'State with this name already exists');
+    }
+
+    const createdState = await this.prismaClient.state.create({
+      data: {
+        code,
+        name,
+        region: input.region,
+      },
+    });
+
+    const summary = toStateSummary(createdState);
+
+    await audit({
+      userId: actor.actorId,
+      entity: 'state',
+      entityId: String(createdState.id),
+      action: 'CREATE',
+      diff: { created: summary },
+      ip: context.ip,
+      userAgent: context.userAgent,
+    });
+
+    return summary;
+  }
+
+  async listCities(params: ListCitiesQuery): Promise<CitySummary[]> {
+    const where: Prisma.CityWhereInput = {};
+    const search = normalizeSearch(params.search);
+
+    if (params.state) {
+      where.state = { code: params.state };
+    }
+
+    if (search) {
+      where.name = { contains: search, mode: 'insensitive' };
+    }
+
+    const cities = await this.prismaClient.city.findMany({
+      where,
+      include: { state: true },
+      orderBy: [{ name: 'asc' }],
+    });
+
+    return cities.map(toCitySummary);
+  }
+
+  async createCity(actor: ActorContext, input: CreateCityBody, context: RequestContext): Promise<CitySummary> {
+    const roles = normalizeRoles(actor.roles);
+
+    if (!(roles.has('ADMIN') || roles.has('EDITOR'))) {
+      throw new HttpError(403, 'INSUFFICIENT_ROLE', 'User lacks required role');
+    }
+
+    const state = await this.prismaClient.state.findUnique({ where: { id: input.stateId } });
+
+    if (!state) {
+      throw new HttpError(404, 'STATE_NOT_FOUND', 'State not found');
+    }
+
+    const name = input.name.trim();
+    const slugSource = input.slug?.trim().length ? input.slug : name;
+    const slug = ensureSlug(slugSource, 'city');
+
+    const existingCityByName = await this.prismaClient.city.findFirst({
+      where: {
+        stateId: state.id,
+        name: { equals: name, mode: 'insensitive' },
+      },
+    });
+
+    if (existingCityByName) {
+      throw new HttpError(409, 'CITY_ALREADY_EXISTS', 'City with this name already exists in the selected state');
+    }
+
+    try {
+      const createdCity = await this.prismaClient.city.create({
+        data: {
+          stateId: state.id,
+          name,
+          slug,
+          isCapital: input.isCapital ?? false,
+          latitude: input.latitude !== undefined ? new Prisma.Decimal(input.latitude) : undefined,
+          longitude: input.longitude !== undefined ? new Prisma.Decimal(input.longitude) : undefined,
+        },
+        include: { state: true },
+      });
+
+      const summary = toCitySummary(createdCity);
+
+      await audit({
+        userId: actor.actorId,
+        entity: 'city',
+        entityId: String(createdCity.id),
+        action: 'CREATE',
+        diff: { created: summary },
+        ip: context.ip,
+        userAgent: context.userAgent,
+      });
+
+      return summary;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new HttpError(409, 'CITY_ALREADY_EXISTS', 'City with this slug already exists in the selected state');
+      }
+
+      throw error;
+    }
+  }
+
+  async listParks(params: ListParksQuery): Promise<ParkSummary[]> {
+    const where: Prisma.ParkWhereInput = {};
+    const search = normalizeSearch(params.search);
+
+    if (params.cityId) {
+      where.cityId = params.cityId;
+    }
+
+    if (search) {
+      where.name = { contains: search, mode: 'insensitive' };
+    }
+
+    const parks = await this.prismaClient.park.findMany({
+      where,
+      include: { city: { include: { state: true } } },
+      orderBy: [{ name: 'asc' }],
+    });
+
+    return parks.map(toParkSummary);
+  }
+
+  async createPark(actor: ActorContext, input: CreateParkBody, context: RequestContext): Promise<ParkSummary> {
+    const roles = normalizeRoles(actor.roles);
+
+    if (!(roles.has('ADMIN') || roles.has('EDITOR'))) {
+      throw new HttpError(403, 'INSUFFICIENT_ROLE', 'User lacks required role');
+    }
+
+    const city = await this.prismaClient.city.findUnique({
+      where: { id: input.cityId },
+      include: { state: true },
+    });
+
+    if (!city) {
+      throw new HttpError(404, 'CITY_NOT_FOUND', 'City not found');
+    }
+
+    const name = input.name.trim();
+    const slugSource = input.slug?.trim().length ? input.slug : name;
+    const slug = ensureSlug(slugSource, 'park');
+
+    const existingParkByName = await this.prismaClient.park.findFirst({
+      where: {
+        cityId: city.id,
+        name: { equals: name, mode: 'insensitive' },
+      },
+    });
+
+    if (existingParkByName) {
+      throw new HttpError(409, 'PARK_ALREADY_EXISTS', 'Park with this name already exists in the selected city');
+    }
+
+    try {
+      const createdPark = await this.prismaClient.park.create({
+        data: {
+          cityId: city.id,
+          name,
+          slug,
+          description: input.description?.trim() ?? null,
+        },
+        include: { city: { include: { state: true } } },
+      });
+
+      const summary = toParkSummary(createdPark);
+
+      await audit({
+        userId: actor.actorId,
+        entity: 'park',
+        entityId: String(createdPark.id),
+        action: 'CREATE',
+        diff: { created: summary },
+        ip: context.ip,
+        userAgent: context.userAgent,
+      });
+
+      return summary;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new HttpError(409, 'PARK_ALREADY_EXISTS', 'Park with this slug already exists in the selected city');
+      }
+
+      throw error;
+    }
+  }
+}
+
+export const adminGeoService = new AdminGeoService();


### PR DESCRIPTION
## Summary
- add a Region enum plus State, City, and Park models with indexes to the Prisma schema
- implement geo validation schemas and services to create/list states, cities, and parks with auditing and slug generation
- expose new /api/admin routes for managing states, cities, and parks

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd640e0c4883248e431fdbf2526802