### PR TITLE
Add admin trails management with media uploads

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -108,6 +108,7 @@ model State {
   updatedAt DateTime @updatedAt
 
   cities City[]
+  trails Trail[]
 
   @@index([name])
   @@index([region])
@@ -124,8 +125,9 @@ model City {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  state State @relation(fields: [stateId], references: [id])
-  parks Park[]
+  state  State   @relation(fields: [stateId], references: [id])
+  parks  Park[]
+  trails Trail[]
 
   @@unique([stateId, slug])
   @@index([stateId, name])
@@ -144,4 +146,70 @@ model Park {
 
   @@unique([cityId, slug])
   @@index([cityId, name])
+}
+
+enum TrailDifficulty {
+  EASY
+  MODERATE
+  HARD
+  EXTREME
+}
+
+model Trail {
+  id              String          @id @default(uuid())
+  slug            String          @unique
+  name            String
+  summary         String?
+  description     String?
+  difficulty      TrailDifficulty @default(MODERATE)
+  distanceKm      Decimal?        @db.Decimal(6, 2)
+  durationMinutes Int?
+  elevationGain   Int?
+  elevationLoss   Int?
+  maxAltitude     Int?
+  minAltitude     Int?
+  stateId         Int?
+  cityId          Int?
+  hasWaterPoints  Boolean         @default(false)
+  hasCamping      Boolean         @default(false)
+  paidEntry       Boolean         @default(false)
+  entryFeeCents   Int?
+  guideFeeCents   Int?
+  meetingPoint    String?
+  notes           String?
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+  deletedAt       DateTime?
+
+  state  State?  @relation(fields: [stateId], references: [id])
+  city   City?   @relation(fields: [cityId], references: [id])
+  medias Media[]
+
+  @@index([stateId])
+  @@index([cityId])
+  @@index([difficulty])
+  @@index([deletedAt])
+}
+
+model Media {
+  id          String    @id @default(uuid())
+  trailId     String?
+  key         String    @unique
+  fileName    String?
+  contentType String?
+  size        Int?
+  title       String?
+  description String?
+  order       Int?
+  publicUrl   String?
+  uploadedAt  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deletedAt   DateTime?
+
+  trail Trail? @relation(fields: [trailId], references: [id])
+
+  @@index([trailId])
+  @@index([deletedAt])
+  @@index([trailId, order])
 }

--- a/api/src/modules/admin/admin.routes.ts
+++ b/api/src/modules/admin/admin.routes.ts
@@ -11,6 +11,8 @@ import { adminCitiesRouter } from '../geo/admin-cities.routes';
 import { adminParksRouter } from '../geo/admin-parks.routes';
 import { adminStatesRouter } from '../geo/admin-states.routes';
 import { adminUsersRouter } from '../users/admin-users.routes';
+import { adminTrailsRouter } from '../trails/admin-trails.routes';
+import { adminMediaRouter } from '../media/admin-media.routes';
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 5 * 1024 * 1024 } });
@@ -35,6 +37,8 @@ router.use('/guides', adminGuidesRouter);
 router.use('/states', adminStatesRouter);
 router.use('/cities', adminCitiesRouter);
 router.use('/parks', adminParksRouter);
+router.use('/trails', adminTrailsRouter);
+router.use('/media', adminMediaRouter);
 
 router.post(
   '/cadastur/import',

--- a/api/src/modules/media/admin-media.routes.ts
+++ b/api/src/modules/media/admin-media.routes.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+
+import { requireRole } from '../../middlewares/rbac';
+import { validate } from '../../middlewares/validation';
+import { adminMediaService } from './media.service';
+import { deleteMediaSchema, type DeleteMediaParams } from './media.schemas';
+
+const router = Router();
+
+const extractRoles = (roles: unknown): string[] => {
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+
+  return roles
+    .map((role) => (typeof role === 'string' ? role.trim() : ''))
+    .filter((role) => role.length > 0);
+};
+
+router.delete(
+  '/:mediaId',
+  requireRole('ADMIN', 'EDITOR'),
+  validate(deleteMediaSchema),
+  async (req, res, next) => {
+    try {
+      const params = req.params as unknown as DeleteMediaParams;
+      const actorRoles = extractRoles(req.user?.roles);
+
+      await adminMediaService.deleteMedia(
+        { actorId: req.user?.sub, roles: actorRoles },
+        params.mediaId,
+        { ip: req.ip, userAgent: req.get('user-agent') },
+      );
+
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export const adminMediaRouter = router;

--- a/api/src/modules/media/media.mappers.ts
+++ b/api/src/modules/media/media.mappers.ts
@@ -1,0 +1,33 @@
+import type { Media } from '@prisma/client';
+
+export type MediaSummary = {
+  id: string;
+  trailId: string | null;
+  key: string;
+  fileName: string | null;
+  contentType: string | null;
+  size: number | null;
+  title: string | null;
+  description: string | null;
+  order: number | null;
+  publicUrl: string | null;
+  uploadedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const toMediaSummary = (media: Media): MediaSummary => ({
+  id: media.id,
+  trailId: media.trailId ?? null,
+  key: media.key,
+  fileName: media.fileName ?? null,
+  contentType: media.contentType ?? null,
+  size: media.size ?? null,
+  title: media.title ?? null,
+  description: media.description ?? null,
+  order: media.order ?? null,
+  publicUrl: media.publicUrl ?? null,
+  uploadedAt: media.uploadedAt ? media.uploadedAt.toISOString() : null,
+  createdAt: media.createdAt.toISOString(),
+  updatedAt: media.updatedAt.toISOString(),
+});

--- a/api/src/modules/media/media.schemas.ts
+++ b/api/src/modules/media/media.schemas.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+const optionalInteger = z
+  .union([z.number(), z.string(), z.null(), z.undefined()])
+  .transform((value, ctx) => {
+    if (value === undefined) {
+      return undefined as number | null | undefined;
+    }
+
+    if (value === null) {
+      return null as number | null;
+    }
+
+    const parseNumeric = (input: number | string): number => {
+      if (typeof input === 'number') {
+        return input;
+      }
+
+      const trimmed = input.trim();
+      if (trimmed.length === 0) {
+        return Number.NaN;
+      }
+
+      if (!/^[-+]?\d+$/.test(trimmed)) {
+        return Number.NaN;
+      }
+
+      return Number.parseInt(trimmed, 10);
+    };
+
+    const numeric = parseNumeric(value);
+
+    if (!Number.isFinite(numeric) || !Number.isInteger(numeric)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Value must be an integer' });
+      return z.NEVER;
+    }
+
+    if (numeric < 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Value must be greater than or equal to zero' });
+      return z.NEVER;
+    }
+
+    return numeric;
+  });
+
+export const createTrailMediaSchema = {
+  params: z.object({
+    id: z.string().uuid(),
+  }),
+  body: z
+    .object({
+      contentType: z.string().trim().min(1),
+      fileName: z.string().trim().min(1).max(255).optional(),
+      size: optionalInteger.optional(),
+      title: z.string().trim().min(1).max(200).optional(),
+      description: z.string().trim().min(1).max(2000).optional(),
+    })
+    .strict(),
+};
+
+export const deleteMediaSchema = {
+  params: z.object({
+    mediaId: z.string().uuid(),
+  }),
+};
+
+export type CreateTrailMediaParams = z.infer<typeof createTrailMediaSchema.params>;
+export type CreateTrailMediaBody = z.infer<typeof createTrailMediaSchema.body> & {
+  size?: number | null;
+};
+export type DeleteMediaParams = z.infer<typeof deleteMediaSchema.params>;

--- a/api/src/modules/media/media.service.ts
+++ b/api/src/modules/media/media.service.ts
@@ -1,0 +1,207 @@
+import { HttpError } from '../../middlewares/error';
+import { prisma, type PrismaClientInstance } from '../../services/prisma';
+import {
+  StorageService,
+  createStorageServiceFromEnv,
+} from '../../services/storage';
+import { audit } from '../audit/audit.service';
+import { toMediaSummary, type MediaSummary } from './media.mappers';
+import type { CreateTrailMediaBody } from './media.schemas';
+
+export type ActorContext = {
+  actorId?: string | null;
+  roles: string[];
+};
+
+export type RequestContext = {
+  ip?: string | null;
+  userAgent?: string | null;
+};
+
+export type PresignedUploadResult = {
+  key: string;
+  uploadUrl: string;
+  publicUrl: string;
+};
+
+export type TrailMediaUploadResult = {
+  media: MediaSummary;
+  upload: PresignedUploadResult;
+};
+
+const normalizeRoles = (roles: string[]): Set<string> => {
+  return new Set(roles.map((role) => role.trim().toUpperCase()).filter((role) => role.length > 0));
+};
+
+const sanitizeNullableText = (value?: string): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export class AdminMediaService {
+  private storageService?: StorageService;
+
+  constructor(
+    private readonly prismaClient: PrismaClientInstance = prisma,
+    private readonly storageFactory: () => StorageService = () => createStorageServiceFromEnv(),
+  ) {}
+
+  private getStorage(): StorageService {
+    if (!this.storageService) {
+      try {
+        this.storageService = this.storageFactory();
+      } catch (error) {
+        throw new HttpError(500, 'STORAGE_NOT_CONFIGURED', 'Storage service is not configured');
+      }
+    }
+
+    return this.storageService;
+  }
+
+  async createTrailMediaUpload(
+    actor: ActorContext,
+    trailId: string,
+    input: CreateTrailMediaBody,
+    context: RequestContext,
+  ): Promise<TrailMediaUploadResult> {
+    const roles = normalizeRoles(actor.roles);
+
+    if (!(roles.has('ADMIN') || roles.has('EDITOR') || roles.has('OPERADOR'))) {
+      throw new HttpError(403, 'INSUFFICIENT_ROLE', 'User lacks required role');
+    }
+
+    const trail = await this.prismaClient.trail.findFirst({
+      where: {
+        id: trailId,
+        deletedAt: null,
+      },
+    });
+
+    if (!trail) {
+      throw new HttpError(404, 'TRAIL_NOT_FOUND', 'Trail not found');
+    }
+
+    const storage = this.getStorage();
+    const fileName = sanitizeNullableText(input.fileName) ?? undefined;
+
+    const upload = await storage.createPresignedUpload(input.contentType, {
+      fileName,
+    });
+
+    const mediaCount = await this.prismaClient.media.count({
+      where: {
+        trailId,
+        deletedAt: null,
+      },
+    });
+
+    const createdMedia = await this.prismaClient.media.create({
+      data: {
+        trailId,
+        key: upload.key,
+        fileName: sanitizeNullableText(input.fileName),
+        contentType: sanitizeNullableText(input.contentType) ?? null,
+        size: input.size ?? null,
+        title: sanitizeNullableText(input.title),
+        description: sanitizeNullableText(input.description),
+        order: mediaCount + 1,
+        publicUrl: upload.publicUrl,
+        uploadedAt: null,
+      },
+    });
+
+    const mediaSummary = toMediaSummary(createdMedia);
+
+    await audit({
+      userId: actor.actorId,
+      entity: 'trail_media',
+      entityId: createdMedia.id,
+      action: 'TRAIL_MEDIA_CREATE',
+      diff: {
+        trailId,
+        mediaId: createdMedia.id,
+        key: createdMedia.key,
+        order: createdMedia.order,
+        contentType: createdMedia.contentType,
+        size: createdMedia.size,
+      },
+      ip: context.ip,
+      userAgent: context.userAgent,
+    });
+
+    return {
+      media: mediaSummary,
+      upload,
+    };
+  }
+
+  async deleteMedia(actor: ActorContext, mediaId: string, context: RequestContext): Promise<void> {
+    const roles = normalizeRoles(actor.roles);
+
+    if (!(roles.has('ADMIN') || roles.has('EDITOR'))) {
+      throw new HttpError(403, 'INSUFFICIENT_ROLE', 'User lacks required role');
+    }
+
+    const now = new Date();
+
+    const result = await this.prismaClient.$transaction(async (tx) => {
+      const media = await tx.media.findFirst({
+        where: {
+          id: mediaId,
+          deletedAt: null,
+        },
+      });
+
+      if (!media) {
+        throw new HttpError(404, 'MEDIA_NOT_FOUND', 'Media not found');
+      }
+
+      await tx.media.update({
+        where: { id: mediaId },
+        data: { deletedAt: now },
+      });
+
+      if (media.trailId) {
+        const remaining = await tx.media.findMany({
+          where: {
+            trailId: media.trailId,
+            deletedAt: null,
+          },
+          orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
+        });
+
+        let order = 1;
+        for (const item of remaining) {
+          if (item.order !== order) {
+            await tx.media.update({
+              where: { id: item.id },
+              data: { order },
+            });
+          }
+          order += 1;
+        }
+      }
+
+      return media;
+    });
+
+    await audit({
+      userId: actor.actorId,
+      entity: 'trail_media',
+      entityId: result.id,
+      action: 'TRAIL_MEDIA_DELETE',
+      diff: {
+        trailId: result.trailId,
+        key: result.key,
+      },
+      ip: context.ip,
+      userAgent: context.userAgent,
+    });
+  }
+}
+
+export const adminMediaService = new AdminMediaService();

--- a/api/src/modules/trails/admin-trails.routes.ts
+++ b/api/src/modules/trails/admin-trails.routes.ts
@@ -1,0 +1,165 @@
+import { Router } from 'express';
+
+import { HttpError } from '../../middlewares/error';
+import { requireRole } from '../../middlewares/rbac';
+import { validate } from '../../middlewares/validation';
+import { adminMediaService } from '../media/media.service';
+import {
+  createTrailMediaSchema,
+  type CreateTrailMediaBody,
+  type CreateTrailMediaParams,
+} from '../media/media.schemas';
+import {
+  createAdminTrailSchema,
+  deleteAdminTrailSchema,
+  getAdminTrailSchema,
+  listAdminTrailsSchema,
+  updateAdminTrailSchema,
+  type CreateAdminTrailBody,
+  type DeleteAdminTrailParams,
+  type GetAdminTrailParams,
+  type ListAdminTrailsQuery,
+  type UpdateAdminTrailBody,
+  type UpdateAdminTrailParams,
+} from './trail.schemas';
+import { adminTrailService } from './trail.service';
+
+const router = Router();
+
+const extractRoles = (roles: unknown): string[] => {
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+
+  return roles
+    .map((role) => (typeof role === 'string' ? role.trim() : ''))
+    .filter((role) => role.length > 0);
+};
+
+router.get(
+  '/',
+  requireRole('ADMIN', 'EDITOR', 'OPERADOR'),
+  validate(listAdminTrailsSchema),
+  async (req, res, next) => {
+    try {
+      const query = req.query as unknown as ListAdminTrailsQuery;
+      const result = await adminTrailService.listTrails(query);
+
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/',
+  requireRole('ADMIN', 'EDITOR'),
+  validate(createAdminTrailSchema),
+  async (req, res, next) => {
+    try {
+      const body = req.body as CreateAdminTrailBody;
+      const actorRoles = extractRoles(req.user?.roles);
+      const trail = await adminTrailService.createTrail(
+        { actorId: req.user?.sub, roles: actorRoles },
+        body,
+        { ip: req.ip, userAgent: req.get('user-agent') },
+      );
+
+      res.status(201).json({ trail });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/:id',
+  requireRole('ADMIN', 'EDITOR', 'OPERADOR'),
+  validate(getAdminTrailSchema),
+  async (req, res, next) => {
+    try {
+      const params = req.params as unknown as GetAdminTrailParams;
+      const trail = await adminTrailService.getTrailById(params.id);
+
+      if (!trail) {
+        throw new HttpError(404, 'TRAIL_NOT_FOUND', 'Trail not found');
+      }
+
+      res.status(200).json({ trail });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.patch(
+  '/:id',
+  requireRole('ADMIN', 'EDITOR'),
+  validate(updateAdminTrailSchema),
+  async (req, res, next) => {
+    try {
+      const params = req.params as unknown as UpdateAdminTrailParams;
+      const body = req.body as UpdateAdminTrailBody;
+      const actorRoles = extractRoles(req.user?.roles);
+      const trail = await adminTrailService.updateTrail(
+        { actorId: req.user?.sub, roles: actorRoles },
+        params.id,
+        body,
+        { ip: req.ip, userAgent: req.get('user-agent') },
+      );
+
+      res.status(200).json({ trail });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.delete(
+  '/:id',
+  requireRole('ADMIN'),
+  validate(deleteAdminTrailSchema),
+  async (req, res, next) => {
+    try {
+      const params = req.params as unknown as DeleteAdminTrailParams;
+      const actorRoles = extractRoles(req.user?.roles);
+
+      await adminTrailService.deleteTrail(
+        { actorId: req.user?.sub, roles: actorRoles },
+        params,
+        { ip: req.ip, userAgent: req.get('user-agent') },
+      );
+
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/:id/media',
+  requireRole('ADMIN', 'EDITOR', 'OPERADOR'),
+  validate(createTrailMediaSchema),
+  async (req, res, next) => {
+    try {
+      const params = req.params as unknown as CreateTrailMediaParams;
+      const body = req.body as CreateTrailMediaBody;
+      const actorRoles = extractRoles(req.user?.roles);
+
+      const upload = await adminMediaService.createTrailMediaUpload(
+        { actorId: req.user?.sub, roles: actorRoles },
+        params.id,
+        body,
+        { ip: req.ip, userAgent: req.get('user-agent') },
+      );
+
+      res.status(201).json(upload);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export const adminTrailsRouter = router;

--- a/api/src/modules/trails/trail.schemas.ts
+++ b/api/src/modules/trails/trail.schemas.ts
@@ -1,0 +1,248 @@
+import { z } from 'zod';
+
+export const TRAIL_DIFFICULTY_VALUES = ['EASY', 'MODERATE', 'HARD', 'EXTREME'] as const;
+
+const trailDifficultyEnum = z.enum(TRAIL_DIFFICULTY_VALUES);
+
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const optionalText = (max: number) =>
+  z
+    .union([z.string().trim().max(max), z.literal(null)])
+    .optional();
+
+const createOptionalNumberSchema = (options: {
+  fieldName: string;
+  allowDecimal: boolean;
+  min?: number;
+  max?: number;
+}) =>
+  z
+    .union([z.number(), z.string(), z.null(), z.undefined()])
+    .transform((value, ctx) => {
+      if (value === undefined) {
+        return undefined as number | null | undefined;
+      }
+
+      if (value === null) {
+        return null as number | null;
+      }
+
+      let numeric: number;
+      if (typeof value === 'number') {
+        numeric = value;
+      } else {
+        const trimmed = value.trim();
+        if (trimmed.length === 0) {
+          return null;
+        }
+
+        numeric = Number(trimmed);
+      }
+
+      if (!Number.isFinite(numeric)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${options.fieldName} must be a valid number`,
+        });
+        return z.NEVER;
+      }
+
+      if (!options.allowDecimal && !Number.isInteger(numeric)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${options.fieldName} must be an integer`,
+        });
+        return z.NEVER;
+      }
+
+      if (options.min !== undefined && numeric < options.min) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${options.fieldName} must be greater than or equal to ${options.min}`,
+        });
+        return z.NEVER;
+      }
+
+      if (options.max !== undefined && numeric > options.max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${options.fieldName} must be less than or equal to ${options.max}`,
+        });
+        return z.NEVER;
+      }
+
+      return numeric;
+    });
+
+const optionalPositiveIntId = z
+  .union([z.number(), z.string(), z.null(), z.undefined()])
+  .transform((value, ctx) => {
+    if (value === undefined) {
+      return undefined as number | null | undefined;
+    }
+
+    if (value === null) {
+      return null as number | null;
+    }
+
+    const toInteger = (input: number | string): number => {
+      if (typeof input === 'number') {
+        return input;
+      }
+
+      const trimmed = input.trim();
+      if (trimmed.length === 0) {
+        return Number.NaN;
+      }
+
+      if (!/^\d+$/.test(trimmed)) {
+        return Number.NaN;
+      }
+
+      return Number.parseInt(trimmed, 10);
+    };
+
+    const numeric = toInteger(value);
+
+    if (!Number.isFinite(numeric) || !Number.isInteger(numeric)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Identifier must be an integer' });
+      return z.NEVER;
+    }
+
+    if (numeric <= 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Identifier must be greater than zero' });
+      return z.NEVER;
+    }
+
+    return numeric;
+  });
+
+const distanceKmSchema = createOptionalNumberSchema({
+  fieldName: 'distanceKm',
+  allowDecimal: true,
+  min: 0,
+});
+
+const durationMinutesSchema = createOptionalNumberSchema({
+  fieldName: 'durationMinutes',
+  allowDecimal: false,
+  min: 0,
+});
+
+const elevationSchema = createOptionalNumberSchema({
+  fieldName: 'elevation',
+  allowDecimal: false,
+});
+
+const altitudeSchema = createOptionalNumberSchema({
+  fieldName: 'altitude',
+  allowDecimal: false,
+});
+
+const centsSchema = createOptionalNumberSchema({
+  fieldName: 'value',
+  allowDecimal: false,
+  min: 0,
+});
+
+const booleanWithDefault = (defaultValue: boolean) => z.boolean().optional().default(defaultValue);
+
+export const listAdminTrailsSchema = {
+  query: z.object({
+    page: z.coerce.number().int().min(1).optional(),
+    pageSize: z.coerce.number().int().min(1).max(100).optional(),
+    state: z.union([z.string().trim(), z.number()]).optional(),
+    city: z.union([z.string().trim(), z.number()]).optional(),
+    difficulty: z.union([z.string(), z.array(z.string())]).optional(),
+    search: z.string().trim().optional(),
+    sort: z.string().trim().optional(),
+  }),
+};
+
+export const createAdminTrailSchema = {
+  body: z
+    .object({
+      name: z.string().trim().min(1).max(200),
+      slug: z
+        .string()
+        .trim()
+        .min(1)
+        .max(150)
+        .regex(slugPattern, 'Slug must contain only lowercase letters, numbers, and hyphens'),
+      summary: optionalText(500),
+      description: optionalText(5000),
+      difficulty: trailDifficultyEnum.optional().default('MODERATE'),
+      distanceKm: distanceKmSchema.optional(),
+      durationMinutes: durationMinutesSchema.optional(),
+      elevationGain: elevationSchema.optional(),
+      elevationLoss: elevationSchema.optional(),
+      maxAltitude: altitudeSchema.optional(),
+      minAltitude: altitudeSchema.optional(),
+      stateId: optionalPositiveIntId.optional(),
+      cityId: optionalPositiveIntId.optional(),
+      hasWaterPoints: booleanWithDefault(false),
+      hasCamping: booleanWithDefault(false),
+      paidEntry: booleanWithDefault(false),
+      entryFeeCents: centsSchema.optional(),
+      guideFeeCents: centsSchema.optional(),
+      meetingPoint: optionalText(500),
+      notes: optionalText(5000),
+    })
+    .strict(),
+};
+
+export const getAdminTrailSchema = {
+  params: z.object({
+    id: z.string().uuid(),
+  }),
+};
+
+export const updateAdminTrailSchema = {
+  params: z.object({
+    id: z.string().uuid(),
+  }),
+  body: z
+    .object({
+      name: z.string().trim().min(1).max(200).optional(),
+      slug: z
+        .string()
+        .trim()
+        .min(1)
+        .max(150)
+        .regex(slugPattern, 'Slug must contain only lowercase letters, numbers, and hyphens')
+        .optional(),
+      summary: optionalText(500),
+      description: optionalText(5000),
+      difficulty: trailDifficultyEnum.optional(),
+      distanceKm: distanceKmSchema.optional(),
+      durationMinutes: durationMinutesSchema.optional(),
+      elevationGain: elevationSchema.optional(),
+      elevationLoss: elevationSchema.optional(),
+      maxAltitude: altitudeSchema.optional(),
+      minAltitude: altitudeSchema.optional(),
+      stateId: optionalPositiveIntId.optional(),
+      cityId: optionalPositiveIntId.optional(),
+      hasWaterPoints: z.boolean().optional(),
+      hasCamping: z.boolean().optional(),
+      paidEntry: z.boolean().optional(),
+      entryFeeCents: centsSchema.optional(),
+      guideFeeCents: centsSchema.optional(),
+      meetingPoint: optionalText(500),
+      notes: optionalText(5000),
+    })
+    .strict(),
+};
+
+export const deleteAdminTrailSchema = {
+  params: z.object({
+    id: z.string().uuid(),
+  }),
+};
+
+export type ListAdminTrailsQuery = z.infer<typeof listAdminTrailsSchema.query>;
+export type CreateAdminTrailBody = z.infer<typeof createAdminTrailSchema.body>;
+export type GetAdminTrailParams = z.infer<typeof getAdminTrailSchema.params>;
+export type UpdateAdminTrailParams = z.infer<typeof updateAdminTrailSchema.params>;
+export type UpdateAdminTrailBody = z.infer<typeof updateAdminTrailSchema.body>;
+export type DeleteAdminTrailParams = z.infer<typeof deleteAdminTrailSchema.params>;

--- a/api/src/modules/trails/trail.service.ts
+++ b/api/src/modules/trails/trail.service.ts
@@ -1,0 +1,813 @@
+import {
+  Prisma,
+  type City,
+  type Media,
+  type State,
+  type Trail,
+  type TrailDifficulty,
+} from '@prisma/client';
+
+import { HttpError } from '../../middlewares/error';
+import { prisma, type PrismaClientInstance } from '../../services/prisma';
+import { audit } from '../audit/audit.service';
+import { toMediaSummary, type MediaSummary } from '../media/media.mappers';
+import type { ActorContext, PaginationMeta, RequestContext } from '../users/user.service';
+import {
+  TRAIL_DIFFICULTY_VALUES,
+  type CreateAdminTrailBody,
+  type DeleteAdminTrailParams,
+  type ListAdminTrailsQuery,
+  type UpdateAdminTrailBody,
+} from './trail.schemas';
+
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+const TRAIL_SORT_FIELD_MAP = new Map<
+  string,
+  (direction: Prisma.SortOrder) => Prisma.TrailOrderByWithRelationInput
+>([
+  ['createdat', (direction) => ({ createdAt: direction })],
+  ['updatedat', (direction) => ({ updatedAt: direction })],
+  ['name', (direction) => ({ name: direction })],
+  ['slug', (direction) => ({ slug: direction })],
+  ['difficulty', (direction) => ({ difficulty: direction })],
+  ['distancekm', (direction) => ({ distanceKm: direction })],
+  ['durationminutes', (direction) => ({ durationMinutes: direction })],
+  ['entryfeecents', (direction) => ({ entryFeeCents: direction })],
+  ['guidefeecents', (direction) => ({ guideFeeCents: direction })],
+]);
+
+const TRAIL_DIFFICULTY_SET = new Set(TRAIL_DIFFICULTY_VALUES);
+
+export type TrailListParams = ListAdminTrailsQuery;
+
+export type StateReference = {
+  id: number;
+  code: string;
+  name: string;
+  region: State['region'];
+};
+
+export type CityReference = {
+  id: number;
+  stateId: number;
+  name: string;
+  slug: string;
+  state: StateReference;
+};
+
+export type TrailSummary = {
+  id: string;
+  slug: string;
+  name: string;
+  summary: string | null;
+  difficulty: TrailDifficulty;
+  distanceKm: number | null;
+  durationMinutes: number | null;
+  elevationGain: number | null;
+  elevationLoss: number | null;
+  maxAltitude: number | null;
+  minAltitude: number | null;
+  stateId: number | null;
+  cityId: number | null;
+  state: StateReference | null;
+  city: CityReference | null;
+  hasWaterPoints: boolean;
+  hasCamping: boolean;
+  paidEntry: boolean;
+  entryFeeCents: number | null;
+  guideFeeCents: number | null;
+  meetingPoint: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+  media: MediaSummary[];
+};
+
+export type TrailDetail = TrailSummary & {
+  description: string | null;
+};
+
+export type TrailListResult = {
+  trails: TrailSummary[];
+  pagination: PaginationMeta;
+};
+
+const decimalToNumber = (value: Prisma.Decimal | null | undefined): number | null => {
+  if (!value) {
+    return null;
+  }
+
+  return value.toNumber();
+};
+
+const toStateReference = (state: State): StateReference => ({
+  id: state.id,
+  code: state.code,
+  name: state.name,
+  region: state.region,
+});
+
+const toCityReference = (city: City & { state: State }): CityReference => ({
+  id: city.id,
+  stateId: city.stateId,
+  name: city.name,
+  slug: city.slug,
+  state: toStateReference(city.state),
+});
+
+const sanitizeOptionalText = (value: string | null | undefined): string | null | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeRoles = (roles: string[]): Set<string> => {
+  return new Set(roles.map((role) => role.trim().toUpperCase()).filter((role) => role.length > 0));
+};
+
+const slugify = (input: string): string => {
+  const normalized = input
+    .normalize('NFD')
+    .replace(/[^\p{Letter}\p{Number}\s-]+/gu, '')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+
+  const slug = normalized
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+
+  return slug;
+};
+
+const ensureSlug = (input: string): string => {
+  const slug = slugify(input);
+
+  if (slug.length === 0) {
+    throw new HttpError(400, 'INVALID_SLUG', 'Unable to derive a valid slug for the trail');
+  }
+
+  return slug;
+};
+
+const buildPaginationMeta = (totalItems: number, page: number, pageSize: number): PaginationMeta => {
+  const totalPages = pageSize === 0 ? 0 : Math.ceil(totalItems / pageSize);
+
+  return {
+    page,
+    pageSize,
+    totalItems,
+    totalPages,
+    hasNextPage: page < totalPages,
+    hasPreviousPage: page > 1,
+  };
+};
+
+const normalizeSort = (input?: string): Prisma.TrailOrderByWithRelationInput => {
+  const defaultOrder: Prisma.TrailOrderByWithRelationInput = { createdAt: 'desc' };
+
+  if (!input || input.trim().length === 0) {
+    return defaultOrder;
+  }
+
+  const [first] = input.split(',');
+  const trimmed = first.trim();
+
+  if (trimmed.length === 0) {
+    return defaultOrder;
+  }
+
+  let direction: Prisma.SortOrder = 'asc';
+  let fieldName = trimmed;
+
+  if (fieldName.startsWith('-')) {
+    direction = 'desc';
+    fieldName = fieldName.slice(1);
+  } else if (fieldName.startsWith('+')) {
+    fieldName = fieldName.slice(1);
+  }
+
+  const normalizedKey = fieldName.toLowerCase().replace(/\s+/g, '').replace(/_/g, '');
+  const builder = TRAIL_SORT_FIELD_MAP.get(normalizedKey);
+
+  if (!builder) {
+    throw new HttpError(400, 'INVALID_SORT', `Cannot sort by "${fieldName}"`);
+  }
+
+  return builder(direction);
+};
+
+const parseDifficultyFilter = (
+  value?: string | string[],
+): TrailDifficulty[] | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const values = Array.isArray(value) ? value : value.split(',');
+  const normalized = values
+    .map((item) => (typeof item === 'string' ? item.trim().toUpperCase() : ''))
+    .filter((item) => item.length > 0);
+
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  const result: TrailDifficulty[] = [];
+
+  for (const difficulty of normalized) {
+    if (!TRAIL_DIFFICULTY_SET.has(difficulty as TrailDifficulty)) {
+      throw new HttpError(400, 'INVALID_DIFFICULTY', `Invalid difficulty "${difficulty}"`);
+    }
+
+    if (!result.includes(difficulty as TrailDifficulty)) {
+      result.push(difficulty as TrailDifficulty);
+    }
+  }
+
+  return result;
+};
+
+const parseNumericId = (value?: string | number): number | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value <= 0) {
+      throw new HttpError(400, 'INVALID_IDENTIFIER', 'Identifier must be a positive integer');
+    }
+
+    return value;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  if (!/^\d+$/.test(trimmed)) {
+    throw new HttpError(400, 'INVALID_IDENTIFIER', 'Identifier must be a positive integer');
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new HttpError(400, 'INVALID_IDENTIFIER', 'Identifier must be a positive integer');
+  }
+
+  return parsed;
+};
+
+const toTrailSummary = (
+  trail: Trail & { state: State | null; city: (City & { state: State }) | null; medias: Media[] },
+): TrailSummary => ({
+  id: trail.id,
+  slug: trail.slug,
+  name: trail.name,
+  summary: trail.summary ?? null,
+  difficulty: trail.difficulty,
+  distanceKm: decimalToNumber(trail.distanceKm),
+  durationMinutes: trail.durationMinutes ?? null,
+  elevationGain: trail.elevationGain ?? null,
+  elevationLoss: trail.elevationLoss ?? null,
+  maxAltitude: trail.maxAltitude ?? null,
+  minAltitude: trail.minAltitude ?? null,
+  stateId: trail.stateId ?? null,
+  cityId: trail.cityId ?? null,
+  state: trail.state ? toStateReference(trail.state) : null,
+  city: trail.city ? toCityReference(trail.city) : null,
+  hasWaterPoints: trail.hasWaterPoints,
+  hasCamping: trail.hasCamping,
+  paidEntry: trail.paidEntry,
+  entryFeeCents: trail.entryFeeCents ?? null,
+  guideFeeCents: trail.guideFeeCents ?? null,
+  meetingPoint: trail.meetingPoint ?? null,
+  notes: trail.notes ?? null,
+  createdAt: trail.createdAt.toISOString(),
+  updatedAt: trail.updatedAt.toISOString(),
+  media: trail.medias.map(toMediaSummary),
+});
+
+const toTrailDetail = (
+  trail: Trail & { state: State | null; city: (City & { state: State }) | null; medias: Media[] },
+): TrailDetail => ({
+  ...toTrailSummary(trail),
+  description: trail.description ?? null,
+});
+
+const decimalFromNumber = (value: number | null | undefined): Prisma.Decimal | null | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  return new Prisma.Decimal(value);
+};
+
+export class AdminTrailService {
+  constructor(private readonly prismaClient: PrismaClientInstance = prisma) {}
+
+  private async ensureUniqueSlug(slug: string, excludeId?: string): Promise<void> {
+    const existing = await this.prismaClient.trail.findFirst({
+      where: {
+        slug,
+        ...(excludeId ? { id: { not: excludeId } } : {}),
+      },
+    });
+
+    if (existing) {
+      throw new HttpError(409, 'TRAIL_SLUG_EXISTS', 'Trail with this slug already exists');
+    }
+  }
+
+  private async resolveState(stateId: number): Promise<State> {
+    const state = await this.prismaClient.state.findUnique({ where: { id: stateId } });
+
+    if (!state) {
+      throw new HttpError(404, 'STATE_NOT_FOUND', 'State not found');
+    }
+
+    return state;
+  }
+
+  private async resolveCity(cityId: number): Promise<City & { state: State }> {
+    const city = await this.prismaClient.city.findUnique({
+      where: { id: cityId },
+      include: { state: true },
+    });
+
+    if (!city) {
+      throw new HttpError(404, 'CITY_NOT_FOUND', 'City not found');
+    }
+
+    return city;
+  }
+
+  async listTrails(params: TrailListParams): Promise<TrailListResult> {
+    const page = Math.max(1, params.page ?? 1);
+    const rawPageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
+    const pageSize = Math.max(1, Math.min(rawPageSize, MAX_PAGE_SIZE));
+    const skip = (page - 1) * pageSize;
+
+    const where: Prisma.TrailWhereInput = {
+      deletedAt: null,
+    };
+
+    const stateId = parseNumericId(params.state);
+    if (stateId !== undefined) {
+      where.stateId = stateId;
+    }
+
+    const cityId = parseNumericId(params.city);
+    if (cityId !== undefined) {
+      where.cityId = cityId;
+    }
+
+    const difficulty = parseDifficultyFilter(params.difficulty);
+    if (difficulty && difficulty.length > 0) {
+      where.difficulty = { in: difficulty };
+    }
+
+    const search = params.search?.trim();
+    if (search && search.length > 0) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { slug: { contains: search, mode: 'insensitive' } },
+        { summary: { contains: search, mode: 'insensitive' } },
+        { description: { contains: search, mode: 'insensitive' } },
+        { meetingPoint: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    const orderBy = normalizeSort(params.sort);
+
+    const [totalItems, trails] = await this.prismaClient.$transaction([
+      this.prismaClient.trail.count({ where }),
+      this.prismaClient.trail.findMany({
+        where,
+        skip,
+        take: pageSize,
+        orderBy,
+        include: {
+          state: true,
+          city: { include: { state: true } },
+          medias: {
+            where: { deletedAt: null },
+            orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
+          },
+        },
+      }),
+    ]);
+
+    const pagination = buildPaginationMeta(totalItems, page, pageSize);
+    const summaries = trails.map(toTrailSummary);
+
+    return { trails: summaries, pagination };
+  }
+
+  async getTrailById(id: string): Promise<TrailDetail | null> {
+    const trail = await this.prismaClient.trail.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        state: true,
+        city: { include: { state: true } },
+        medias: {
+          where: { deletedAt: null },
+          orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
+        },
+      },
+    });
+
+    if (!trail) {
+      return null;
+    }
+
+    return toTrailDetail(trail);
+  }
+
+  async createTrail(
+    actor: ActorContext,
+    input: CreateAdminTrailBody,
+    context: RequestContext,
+  ): Promise<TrailDetail> {
+    const roles = normalizeRoles(actor.roles);
+
+    if (!(roles.has('ADMIN') || roles.has('EDITOR'))) {
+      throw new HttpError(403, 'INSUFFICIENT_ROLE', 'User lacks required role');
+    }
+
+    const name = input.name.trim();
+    const slug = ensureSlug(input.slug);
+
+    await this.ensureUniqueSlug(slug);
+
+    let resolvedStateId: number | null | undefined = input.stateId;
+    let resolvedCityId: number | null | undefined = input.cityId;
+    let resolvedCity: (City & { state: State }) | null = null;
+
+    if (resolvedCityId !== undefined && resolvedCityId !== null) {
+      resolvedCity = await this.resolveCity(resolvedCityId);
+      resolvedCityId = resolvedCity.id;
+      resolvedStateId = resolvedCity.stateId;
+    } else if (resolvedCityId === null) {
+      resolvedCityId = null;
+    }
+
+    if (resolvedStateId !== undefined) {
+      if (resolvedStateId === null) {
+        if (resolvedCityId) {
+          throw new HttpError(
+            400,
+            'CITY_STATE_MISMATCH',
+            'City cannot be associated without a valid state',
+          );
+        }
+      } else {
+        const state = await this.resolveState(resolvedStateId);
+        resolvedStateId = state.id;
+
+        if (resolvedCity && resolvedCity.stateId !== state.id) {
+          throw new HttpError(400, 'CITY_STATE_MISMATCH', 'City does not belong to the specified state');
+        }
+      }
+    } else if (resolvedCity) {
+      resolvedStateId = resolvedCity.stateId;
+    }
+
+    const createData: Prisma.TrailUncheckedCreateInput = {
+      slug,
+      name,
+      summary: sanitizeOptionalText(input.summary) ?? null,
+      description: sanitizeOptionalText(input.description) ?? null,
+      difficulty: (input.difficulty ?? 'MODERATE') as TrailDifficulty,
+      distanceKm: decimalFromNumber(input.distanceKm),
+      durationMinutes: input.durationMinutes ?? null,
+      elevationGain: input.elevationGain ?? null,
+      elevationLoss: input.elevationLoss ?? null,
+      maxAltitude: input.maxAltitude ?? null,
+      minAltitude: input.minAltitude ?? null,
+      stateId: resolvedStateId ?? null,
+      cityId: resolvedCityId ?? null,
+      hasWaterPoints: input.hasWaterPoints,
+      hasCamping: input.hasCamping,
+      paidEntry: input.paidEntry,
+      entryFeeCents: input.entryFeeCents ?? null,
+      guideFeeCents: input.guideFeeCents ?? null,
+      meetingPoint: sanitizeOptionalText(input.meetingPoint) ?? null,
+      notes: sanitizeOptionalText(input.notes) ?? null,
+    };
+
+    const createdTrail = await this.prismaClient.trail.create({
+      data: createData,
+      include: {
+        state: true,
+        city: { include: { state: true } },
+        medias: {
+          where: { deletedAt: null },
+          orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
+        },
+      },
+    });
+
+    await audit({
+      userId: actor.actorId,
+      entity: 'trail',
+      entityId: createdTrail.id,
+      action: 'TRAIL_CREATE',
+      diff: {
+        name,
+        slug,
+        stateId: createdTrail.stateId,
+        cityId: createdTrail.cityId,
+        difficulty: createdTrail.difficulty,
+      },
+      ip: context.ip,
+      userAgent: context.userAgent,
+    });
+
+    return toTrailDetail(createdTrail);
+  }
+
+  async updateTrail(
+    actor: ActorContext,
+    id: string,
+    body: UpdateAdminTrailBody,
+    context: RequestContext,
+  ): Promise<TrailDetail> {
+    const roles = normalizeRoles(actor.roles);
+
+    if (!(roles.has('ADMIN') || roles.has('EDITOR'))) {
+      throw new HttpError(403, 'INSUFFICIENT_ROLE', 'User lacks required role');
+    }
+
+    const existing = await this.prismaClient.trail.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        state: true,
+        city: { include: { state: true } },
+        medias: {
+          where: { deletedAt: null },
+          orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
+        },
+      },
+    });
+
+    if (!existing) {
+      throw new HttpError(404, 'TRAIL_NOT_FOUND', 'Trail not found');
+    }
+
+    const updateData: Prisma.TrailUncheckedUpdateInput = {};
+    const diff: Record<string, unknown> = {};
+
+    if (body.name !== undefined) {
+      const trimmed = body.name.trim();
+      updateData.name = trimmed;
+      diff.name = trimmed;
+    }
+
+    if (body.slug !== undefined) {
+      const newSlug = ensureSlug(body.slug);
+      await this.ensureUniqueSlug(newSlug, id);
+      updateData.slug = newSlug;
+      diff.slug = newSlug;
+    }
+
+    const summary = sanitizeOptionalText(body.summary);
+    if (summary !== undefined) {
+      updateData.summary = summary;
+      diff.summary = summary;
+    }
+
+    const description = sanitizeOptionalText(body.description);
+    if (description !== undefined) {
+      updateData.description = description;
+      diff.description = description;
+    }
+
+    if (body.difficulty !== undefined) {
+      updateData.difficulty = body.difficulty as TrailDifficulty;
+      diff.difficulty = body.difficulty;
+    }
+
+    if (body.distanceKm !== undefined) {
+      updateData.distanceKm = decimalFromNumber(body.distanceKm);
+      diff.distanceKm = body.distanceKm;
+    }
+
+    if (body.durationMinutes !== undefined) {
+      updateData.durationMinutes = body.durationMinutes ?? null;
+      diff.durationMinutes = body.durationMinutes;
+    }
+
+    if (body.elevationGain !== undefined) {
+      updateData.elevationGain = body.elevationGain ?? null;
+      diff.elevationGain = body.elevationGain;
+    }
+
+    if (body.elevationLoss !== undefined) {
+      updateData.elevationLoss = body.elevationLoss ?? null;
+      diff.elevationLoss = body.elevationLoss;
+    }
+
+    if (body.maxAltitude !== undefined) {
+      updateData.maxAltitude = body.maxAltitude ?? null;
+      diff.maxAltitude = body.maxAltitude;
+    }
+
+    if (body.minAltitude !== undefined) {
+      updateData.minAltitude = body.minAltitude ?? null;
+      diff.minAltitude = body.minAltitude;
+    }
+
+    if (body.hasWaterPoints !== undefined) {
+      updateData.hasWaterPoints = body.hasWaterPoints;
+      diff.hasWaterPoints = body.hasWaterPoints;
+    }
+
+    if (body.hasCamping !== undefined) {
+      updateData.hasCamping = body.hasCamping;
+      diff.hasCamping = body.hasCamping;
+    }
+
+    if (body.paidEntry !== undefined) {
+      updateData.paidEntry = body.paidEntry;
+      diff.paidEntry = body.paidEntry;
+    }
+
+    if (body.entryFeeCents !== undefined) {
+      updateData.entryFeeCents = body.entryFeeCents ?? null;
+      diff.entryFeeCents = body.entryFeeCents;
+    }
+
+    if (body.guideFeeCents !== undefined) {
+      updateData.guideFeeCents = body.guideFeeCents ?? null;
+      diff.guideFeeCents = body.guideFeeCents;
+    }
+
+    const meetingPoint = sanitizeOptionalText(body.meetingPoint);
+    if (meetingPoint !== undefined) {
+      updateData.meetingPoint = meetingPoint;
+      diff.meetingPoint = meetingPoint;
+    }
+
+    const notes = sanitizeOptionalText(body.notes);
+    if (notes !== undefined) {
+      updateData.notes = notes;
+      diff.notes = notes;
+    }
+
+    let resolvedStateId: number | null = existing.stateId ?? null;
+    let resolvedCityId: number | null = existing.cityId ?? null;
+    let currentCity: (City & { state: State }) | null = existing.city ? existing.city : null;
+
+    const stateProvided = body.stateId !== undefined;
+    const cityProvided = body.cityId !== undefined;
+
+    if (cityProvided) {
+      if (body.cityId === null) {
+        resolvedCityId = null;
+        currentCity = null;
+      } else if (body.cityId !== undefined) {
+        currentCity = await this.resolveCity(body.cityId);
+        resolvedCityId = currentCity.id;
+      }
+    }
+
+    if (stateProvided) {
+      if (body.stateId === null) {
+        if (resolvedCityId) {
+          throw new HttpError(
+            400,
+            'CITY_STATE_MISMATCH',
+            'City cannot be associated without a valid state',
+          );
+        }
+
+        resolvedStateId = null;
+      } else if (body.stateId !== undefined) {
+        const state = await this.resolveState(body.stateId);
+        resolvedStateId = state.id;
+      }
+    }
+
+    if (currentCity) {
+      if (resolvedStateId === null) {
+        throw new HttpError(400, 'CITY_STATE_MISMATCH', 'City cannot be associated without a valid state');
+      }
+
+      if (stateProvided) {
+        if (resolvedStateId !== currentCity.stateId) {
+          throw new HttpError(400, 'CITY_STATE_MISMATCH', 'City does not belong to the specified state');
+        }
+      } else {
+        resolvedStateId = currentCity.stateId;
+      }
+    }
+
+    if (stateProvided || (cityProvided && currentCity)) {
+      updateData.stateId = resolvedStateId ?? null;
+      diff.stateId = resolvedStateId ?? null;
+    }
+
+    if (cityProvided) {
+      updateData.cityId = resolvedCityId ?? null;
+      diff.cityId = resolvedCityId ?? null;
+    }
+
+    const updatedTrail = await this.prismaClient.trail.update({
+      where: { id: existing.id },
+      data: updateData,
+      include: {
+        state: true,
+        city: { include: { state: true } },
+        medias: {
+          where: { deletedAt: null },
+          orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
+        },
+      },
+    });
+
+    await audit({
+      userId: actor.actorId,
+      entity: 'trail',
+      entityId: updatedTrail.id,
+      action: 'TRAIL_UPDATE',
+      diff,
+      ip: context.ip,
+      userAgent: context.userAgent,
+    });
+
+    return toTrailDetail(updatedTrail);
+  }
+
+  async deleteTrail(
+    actor: ActorContext,
+    params: DeleteAdminTrailParams,
+    context: RequestContext,
+  ): Promise<void> {
+    const roles = normalizeRoles(actor.roles);
+
+    if (!roles.has('ADMIN')) {
+      throw new HttpError(403, 'INSUFFICIENT_ROLE', 'User lacks required role');
+    }
+
+    const now = new Date();
+
+    await this.prismaClient.$transaction(async (tx) => {
+      const existing = await tx.trail.findFirst({
+        where: { id: params.id, deletedAt: null },
+        include: {
+          medias: {
+            where: { deletedAt: null },
+            select: { id: true },
+          },
+        },
+      });
+
+      if (!existing) {
+        throw new HttpError(404, 'TRAIL_NOT_FOUND', 'Trail not found');
+      }
+
+      await tx.trail.update({
+        where: { id: params.id },
+        data: { deletedAt: now },
+      });
+
+      if (existing.medias.length > 0) {
+        await tx.media.updateMany({
+          where: { trailId: params.id, deletedAt: null },
+          data: { deletedAt: now },
+        });
+      }
+
+      return existing;
+    });
+
+    await audit({
+      userId: actor.actorId,
+      entity: 'trail',
+      entityId: params.id,
+      action: 'TRAIL_DELETE',
+      diff: { trailId: params.id },
+      ip: context.ip,
+      userAgent: context.userAgent,
+    });
+  }
+}
+
+export const adminTrailService = new AdminTrailService();

--- a/api/src/services/storage.ts
+++ b/api/src/services/storage.ts
@@ -1,17 +1,26 @@
 import { S3Client, type S3ClientConfig } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { randomUUID } from 'node:crypto';
+import { extname } from 'node:path';
 
 export interface StorageServiceOptions {
   bucket: string;
   basePath?: string;
+  publicBaseUrl?: string;
 }
 
-export interface SignedUpload {
-  url: string;
-  fields: Record<string, string>;
+export interface PresignedUpload {
   key: string;
+  uploadUrl: string;
+  publicUrl: string;
+}
+
+export interface CreatePresignedUploadOptions {
+  expiresInSeconds?: number;
+  fileName?: string;
+  metadata?: Record<string, string>;
+  contentDisposition?: string;
 }
 
 export class StorageService {
@@ -21,28 +30,97 @@ export class StorageService {
 
   private readonly basePath?: string;
 
+  private readonly publicBaseUrl?: string;
+
   constructor(config: S3ClientConfig, options: StorageServiceOptions) {
     this.client = new S3Client(config);
     this.bucket = options.bucket;
     this.basePath = options.basePath;
+    this.publicBaseUrl = options.publicBaseUrl;
   }
 
-  async createPresignedUpload(contentType: string, expiresInSeconds = 900): Promise<SignedUpload> {
-    const keySegments = [this.basePath, randomUUID()].filter(Boolean);
-    const key = keySegments.join('/');
+  private buildObjectKey(fileName?: string): string {
+    const extension = fileName ? extname(fileName).toLowerCase() : '';
+    const sanitizedExtension = extension.replace(/[^a-z0-9.]/g, '');
+    const uniqueName = `${randomUUID()}${sanitizedExtension}`;
+    const segments = [this.basePath, uniqueName].filter((segment): segment is string => Boolean(segment && segment.length > 0));
+
+    return segments.join('/');
+  }
+
+  private buildPublicUrl(key: string): string {
+    if (this.publicBaseUrl) {
+      const trimmed = this.publicBaseUrl.replace(/\/+$|^\/+/, '');
+      if (trimmed.length === 0) {
+        return `https://${this.bucket}.s3.amazonaws.com/${key}`;
+      }
+
+      return `${trimmed}/${key}`;
+    }
+
+    return `https://${this.bucket}.s3.amazonaws.com/${key}`;
+  }
+
+  async createPresignedUpload(
+    contentType: string,
+    options: CreatePresignedUploadOptions = {},
+  ): Promise<PresignedUpload> {
+    const key = this.buildObjectKey(options.fileName);
 
     const command = new PutObjectCommand({
       Bucket: this.bucket,
       Key: key,
       ContentType: contentType,
+      Metadata: options.metadata,
+      ContentDisposition: options.contentDisposition,
     });
 
-    const url = await getSignedUrl(this.client, command, { expiresIn: expiresInSeconds });
+    const uploadUrl = await getSignedUrl(this.client, command, {
+      expiresIn: options.expiresInSeconds ?? 900,
+    });
 
     return {
-      url,
-      fields: {},
       key,
+      uploadUrl,
+      publicUrl: this.buildPublicUrl(key),
     };
   }
 }
+
+export const createStorageServiceFromEnv = (): StorageService => {
+  const bucket = process.env.STORAGE_BUCKET;
+
+  if (!bucket) {
+    throw new Error('STORAGE_BUCKET is not configured');
+  }
+
+  const region = process.env.STORAGE_REGION ?? 'auto';
+  const endpoint = process.env.STORAGE_ENDPOINT;
+  const accessKeyId = process.env.STORAGE_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.STORAGE_SECRET_ACCESS_KEY;
+  const basePath = process.env.STORAGE_BASE_PATH;
+  const publicBaseUrl = process.env.STORAGE_PUBLIC_BASE_URL;
+  const forcePathStyle = process.env.STORAGE_FORCE_PATH_STYLE === 'true';
+
+  const config: S3ClientConfig = {
+    region,
+  };
+
+  if (endpoint) {
+    config.endpoint = endpoint;
+  }
+
+  if (accessKeyId && secretAccessKey) {
+    config.credentials = { accessKeyId, secretAccessKey };
+  }
+
+  if (forcePathStyle) {
+    config.forcePathStyle = true;
+  }
+
+  return new StorageService(config, {
+    bucket,
+    basePath,
+    publicBaseUrl,
+  });
+};


### PR DESCRIPTION
## Summary
- extend the Prisma schema with Trail and Media models and enhance the storage service to return presigned upload URLs with public access hints
- add admin-facing trail schemas, service, and routes covering listing, filtering, CRUD, slug validation, and soft delete flows
- implement a media module to provision presigned uploads, persist metadata, and expose deletion endpoints wired into the admin router

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd768066dc8324852782f3774533ff