### PR TITLE
feat(admin): add cadastur CSV import with preview

### DIFF
--- a/api/src/modules/guides/guide.service.ts
+++ b/api/src/modules/guides/guide.service.ts
@@ -1,9 +1,24 @@
-import { Prisma, type GuideProfile, type User, GuideVerificationStatus } from '@prisma/client';
+import {
+  Prisma,
+  type GuideProfile,
+  type User,
+  GuideVerificationStatus,
+  UserStatus,
+} from '@prisma/client';
+import bcrypt from 'bcrypt';
+import { randomUUID } from 'node:crypto';
 
 import type { ActorContext, PaginationMeta, RequestContext, UserSummary } from '../users/user.service';
 import { HttpError } from '../../middlewares/error';
 import { prisma, type PrismaClientInstance } from '../../services/prisma';
 import { audit } from '../audit/audit.service';
+import {
+  parseCadasturCsv,
+  CadasturCsvError,
+  type CadasturCsvRow,
+  type CadasturFieldMapping,
+  evaluateCadasturStatus,
+} from '../../services/cadastur';
 import { GUIDE_VERIFICATION_STATUS_VALUES } from './guide.schemas';
 
 const DEFAULT_PAGE_SIZE = 20;
@@ -54,6 +69,47 @@ export type GuideListItem = {
 export type GuideListResult = {
   guides: GuideListItem[];
   pagination: PaginationMeta;
+};
+
+type CadasturImportIssue = {
+  linha: number;
+  erros: string[];
+  dados: Record<string, string>;
+};
+
+type CadasturImportSummary = {
+  criar: number;
+  atualizar: number;
+  vincular: number;
+};
+
+export type CadasturImportPreview = {
+  total: number;
+  validos: number;
+  invalidos: CadasturImportIssue[];
+  mapeamentoCampos: CadasturFieldMapping;
+  simulacao: CadasturImportSummary;
+};
+
+export type CadasturImportResult = CadasturImportPreview & {
+  processados: number;
+  criados: number;
+  atualizados: number;
+  vinculados: number;
+};
+
+type CadasturImportAction = 'CREATE' | 'UPDATE' | 'ATTACH';
+
+type CadasturImportCandidate = {
+  row: CadasturCsvRow;
+  action: CadasturImportAction;
+  existingGuide?: GuideProfile & { user: User };
+  existingUser?: User & { guideProfile: GuideProfile | null };
+};
+
+type CadasturImportSimulation = {
+  preview: CadasturImportPreview;
+  candidates: CadasturImportCandidate[];
 };
 
 const buildPaginationMeta = (totalItems: number, page: number, pageSize: number): PaginationMeta => {
@@ -128,6 +184,64 @@ const parseVerificationFilter = (
 
     if (!result.includes(status as GuideVerificationStatus)) {
       result.push(status as GuideVerificationStatus);
+    }
+  }
+
+  return result;
+};
+
+const createImportIssue = (row: CadasturCsvRow, errors: string[]): CadasturImportIssue => ({
+  linha: row.rowNumber,
+  erros: Array.from(new Set(errors)),
+  dados: row.raw,
+});
+
+const formatCertificateDate = (iso: string | null, fallback: string | null): string | null => {
+  if (fallback && fallback.trim().length > 0) {
+    return fallback;
+  }
+
+  if (!iso) {
+    return null;
+  }
+
+  try {
+    return new Date(iso).toISOString().slice(0, 10);
+  } catch {
+    return fallback ?? null;
+  }
+};
+
+const buildLanguages = (row: CadasturCsvRow): string[] => {
+  return row.normalized.languages.length > 0 ? row.normalized.languages : [];
+};
+
+const buildServiceAreas = (row: CadasturCsvRow): string[] => {
+  const areas = [...row.normalized.serviceAreas];
+  const { municipality, uf } = row.normalized;
+
+  if (areas.length === 0) {
+    if (municipality && uf) {
+      areas.push(`${municipality}/${uf}`);
+    } else if (municipality) {
+      areas.push(municipality);
+    } else if (uf) {
+      areas.push(uf);
+    }
+  }
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const area of areas) {
+    const key = area.trim().toLowerCase();
+    if (key.length === 0) {
+      continue;
+    }
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(area);
     }
   }
 
@@ -212,6 +326,380 @@ export class AdminGuideService {
     return {
       guides: guides.map(toGuideListItem),
       pagination: buildPaginationMeta(totalItems, page, pageSize),
+    };
+  }
+
+  private async simulateCadasturImport(file: Buffer): Promise<CadasturImportSimulation> {
+    let parsed;
+    try {
+      parsed = parseCadasturCsv(file);
+    } catch (error) {
+      if (error instanceof CadasturCsvError) {
+        throw new HttpError(400, 'INVALID_CADASTUR_CSV', error.message);
+      }
+      throw error;
+    }
+
+    const invalids: CadasturImportIssue[] = [];
+    const validRows: CadasturCsvRow[] = [];
+    const cadasturSeen = new Map<string, number>();
+    const emailSeen = new Map<string, number>();
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    for (const row of parsed.rows) {
+      const errors: string[] = [];
+      const normalized = row.normalized;
+
+      const cadNumber = normalized.cadasturNumber;
+      if (!cadNumber) {
+        errors.push('Número Cadastur ausente ou inválido');
+      } else if (cadasturSeen.has(cadNumber)) {
+        const previousLine = cadasturSeen.get(cadNumber);
+        errors.push(`Número Cadastur duplicado${previousLine ? ` (linha ${previousLine})` : ''}`);
+      } else {
+        cadasturSeen.set(cadNumber, row.rowNumber);
+      }
+
+      const email = normalized.email;
+      if (!email) {
+        errors.push('Email ausente ou inválido');
+      } else if (emailSeen.has(email)) {
+        const previousLine = emailSeen.get(email);
+        errors.push(`Email duplicado no arquivo${previousLine ? ` (linha ${previousLine})` : ''}`);
+      } else {
+        emailSeen.set(email, row.rowNumber);
+      }
+
+      if (!normalized.name) {
+        errors.push('Nome do guia obrigatório');
+      }
+
+      if (normalized.certificateValidityOriginal && !normalized.certificateValidity) {
+        errors.push('Data de validade do certificado inválida');
+      }
+
+      if (normalized.certificateValidity) {
+        const expiry = new Date(normalized.certificateValidity);
+        if (!Number.isNaN(expiry.getTime())) {
+          if (expiry.getTime() < today.getTime()) {
+            const formattedDate = formatCertificateDate(
+              normalized.certificateValidity,
+              normalized.certificateValidityOriginal,
+            );
+            errors.push(
+              `Certificado expirado${formattedDate ? ` em ${formattedDate}` : ''}`,
+            );
+          }
+        }
+      }
+
+      const statusEvaluation = evaluateCadasturStatus(normalized.status);
+      const statusLabel = normalized.statusOriginal ?? normalized.status ?? null;
+
+      if (statusEvaluation === 'INACTIVE') {
+        errors.push(
+          `Status inativo no Cadastur${statusLabel ? ` (${statusLabel})` : ''}`,
+        );
+      } else if (statusEvaluation === 'UNKNOWN' && normalized.status) {
+        errors.push(
+          `Status não reconhecido${statusLabel ? ` (${statusLabel})` : ''}`,
+        );
+      }
+
+      if (errors.length > 0) {
+        invalids.push(createImportIssue(row, errors));
+        continue;
+      }
+
+      validRows.push(row);
+    }
+
+    const summary: CadasturImportSummary = { criar: 0, atualizar: 0, vincular: 0 };
+    const candidates: CadasturImportCandidate[] = [];
+
+    if (validRows.length > 0) {
+      const cadNumbers = Array.from(
+        new Set(validRows.map((row) => row.normalized.cadasturNumber!)),
+      );
+      const emails = Array.from(new Set(validRows.map((row) => row.normalized.email!)));
+
+      const [existingGuides, existingUsers] = await Promise.all([
+        cadNumbers.length > 0
+          ? this.prismaClient.guideProfile.findMany({
+              where: { cadasturNumber: { in: cadNumbers } },
+              include: { user: true },
+            })
+          : Promise.resolve([]),
+        emails.length > 0
+          ? this.prismaClient.user.findMany({
+              where: { email: { in: emails } },
+              include: { guideProfile: true },
+            })
+          : Promise.resolve([]),
+      ]);
+
+      const guideByCadastur = new Map<string, GuideProfile & { user: User }>();
+      for (const guide of existingGuides) {
+        if (guide.cadasturNumber) {
+          guideByCadastur.set(guide.cadasturNumber, guide);
+        }
+      }
+
+      const userByEmail = new Map<string, User & { guideProfile: GuideProfile | null }>();
+      for (const user of existingUsers) {
+        userByEmail.set(user.email.toLowerCase(), user);
+      }
+
+      for (const row of validRows) {
+        const normalized = row.normalized;
+        const cadNumber = normalized.cadasturNumber!;
+        const email = normalized.email!;
+        const errors: string[] = [];
+
+        let existingGuide = guideByCadastur.get(cadNumber);
+        const existingUser = userByEmail.get(email);
+
+        if (!existingGuide && existingUser?.guideProfile) {
+          const userGuide = existingUser.guideProfile;
+          if (userGuide) {
+            if (userGuide.cadasturNumber && userGuide.cadasturNumber !== cadNumber) {
+              errors.push(`Usuário já vinculado ao Cadastur ${userGuide.cadasturNumber}`);
+            } else {
+              existingGuide = {
+                ...userGuide,
+                user: existingUser,
+              } as GuideProfile & { user: User };
+            }
+          }
+        }
+
+        if (existingGuide) {
+          const guideUserEmail = existingGuide.user.email.toLowerCase();
+          if (guideUserEmail !== email && existingUser && existingUser.id !== existingGuide.userId) {
+            errors.push('Email já associado a outro usuário');
+          }
+        } else if (
+          existingUser &&
+          existingUser.guideProfile &&
+          existingUser.guideProfile.cadasturNumber &&
+          existingUser.guideProfile.cadasturNumber !== cadNumber
+        ) {
+          errors.push(`Usuário já vinculado ao Cadastur ${existingUser.guideProfile.cadasturNumber}`);
+        }
+
+        if (errors.length > 0) {
+          invalids.push(createImportIssue(row, errors));
+          continue;
+        }
+
+        if (existingGuide) {
+          candidates.push({ row, action: 'UPDATE', existingGuide });
+          summary.atualizar += 1;
+        } else if (existingUser) {
+          candidates.push({ row, action: 'ATTACH', existingUser });
+          summary.vincular += 1;
+        } else {
+          candidates.push({ row, action: 'CREATE' });
+          summary.criar += 1;
+        }
+      }
+    }
+
+    return {
+      preview: {
+        total: parsed.rows.length,
+        validos: candidates.length,
+        invalidos,
+        mapeamentoCampos: parsed.fieldMapping,
+        simulacao: summary,
+      },
+      candidates,
+    };
+  }
+
+  async previewCadasturImport(file: Buffer): Promise<CadasturImportPreview> {
+    const simulation = await this.simulateCadasturImport(file);
+    return simulation.preview;
+  }
+
+  async importCadasturFromCsv(
+    actor: ActorContext,
+    file: Buffer,
+    fileName: string,
+    context: RequestContext,
+  ): Promise<CadasturImportResult> {
+    const simulation = await this.simulateCadasturImport(file);
+    const { preview, candidates } = simulation;
+
+    let created = 0;
+    let updated = 0;
+    let attached = 0;
+
+    if (candidates.length > 0) {
+      const now = new Date();
+
+      await this.prismaClient.$transaction(async (tx) => {
+        for (const candidate of candidates) {
+          const normalized = candidate.row.normalized;
+          const languages = buildLanguages(candidate.row);
+          const serviceAreas = buildServiceAreas(candidate.row);
+          const displayName = normalized.name ?? candidate.row.raw['nome'] ?? null;
+          const cadNumber = normalized.cadasturNumber!;
+          const email = normalized.email!;
+          const name = normalized.name ?? null;
+
+          if (candidate.action === 'UPDATE') {
+            const guide = candidate.existingGuide!;
+            const user = guide.user;
+
+            const userUpdate: Prisma.UserUpdateInput = {};
+            if (name && name !== user.name) {
+              userUpdate.name = name;
+            }
+            if (user.email.toLowerCase() !== email) {
+              userUpdate.email = email;
+            }
+            if (user.role.toUpperCase() !== 'GUIA') {
+              userUpdate.role = 'GUIA';
+            }
+            if (user.status !== UserStatus.ACTIVE) {
+              userUpdate.status = UserStatus.ACTIVE;
+              userUpdate.deletedAt = null;
+            } else if (user.deletedAt) {
+              userUpdate.deletedAt = null;
+            }
+
+            if (Object.keys(userUpdate).length > 0) {
+              await tx.user.update({
+                where: { id: user.id },
+                data: userUpdate,
+              });
+            }
+
+            await tx.guideProfile.update({
+              where: { id: guide.id },
+              data: {
+                displayName: displayName ?? guide.displayName ?? null,
+                cadasturNumber: cadNumber,
+                languages,
+                serviceAreas,
+                verificationStatus: GuideVerificationStatus.VERIFIED,
+                verificationReviewedAt: now,
+                verificationReviewedById: actor.actorId ?? guide.verificationReviewedById ?? null,
+                verifiedAt: now,
+                rejectedAt: null,
+                deletedAt: null,
+              },
+            });
+
+            updated += 1;
+          } else if (candidate.action === 'ATTACH') {
+            const user = candidate.existingUser!;
+
+            const userUpdate: Prisma.UserUpdateInput = {};
+            if (name && name !== user.name) {
+              userUpdate.name = name;
+            }
+            if (user.role.toUpperCase() !== 'GUIA') {
+              userUpdate.role = 'GUIA';
+            }
+            if (user.status !== UserStatus.ACTIVE) {
+              userUpdate.status = UserStatus.ACTIVE;
+              userUpdate.deletedAt = null;
+            } else if (user.deletedAt) {
+              userUpdate.deletedAt = null;
+            }
+
+            if (Object.keys(userUpdate).length > 0) {
+              await tx.user.update({
+                where: { id: user.id },
+                data: userUpdate,
+              });
+            }
+
+            await tx.guideProfile.create({
+              data: {
+                userId: user.id,
+                displayName: displayName ?? user.name ?? null,
+                cadasturNumber: cadNumber,
+                languages,
+                serviceAreas,
+                verificationStatus: GuideVerificationStatus.VERIFIED,
+                verificationReviewedAt: now,
+                verificationReviewedById: actor.actorId ?? null,
+                verifiedAt: now,
+                rejectedAt: null,
+                deletedAt: null,
+              },
+            });
+
+            attached += 1;
+          } else {
+            const passwordHash = await bcrypt.hash(randomUUID(), 10);
+
+            await tx.user.create({
+              data: {
+                email,
+                passwordHash,
+                name,
+                role: 'GUIA',
+                status: UserStatus.ACTIVE,
+                guideProfile: {
+                  create: {
+                    displayName: displayName ?? name ?? null,
+                    cadasturNumber: cadNumber,
+                    languages,
+                    serviceAreas,
+                    verificationStatus: GuideVerificationStatus.VERIFIED,
+                    verificationReviewedAt: now,
+                    verificationReviewedById: actor.actorId ?? null,
+                    verifiedAt: now,
+                    rejectedAt: null,
+                    deletedAt: null,
+                  },
+                },
+              },
+            });
+
+            created += 1;
+          }
+        }
+      });
+    }
+
+    await audit({
+      userId: actor.actorId,
+      entity: 'cadastur',
+      entityId: null,
+      action: 'IMPORT',
+      diff: {
+        fileName,
+        total: preview.total,
+        validos: preview.validos,
+        invalidos: preview.invalidos.length,
+        criados: created,
+        atualizados: updated,
+        vinculados: attached,
+      },
+      ip: context.ip,
+      userAgent: context.userAgent,
+    });
+
+    return {
+      total: preview.total,
+      validos: preview.validos,
+      invalidos: preview.invalidos,
+      mapeamentoCampos: preview.mapeamentoCampos,
+      simulacao: {
+        criar: created,
+        atualizar: updated,
+        vincular: attached,
+      },
+      processados: candidates.length,
+      criados: created,
+      atualizados: updated,
+      vinculados: attached,
     };
   }
 

--- a/api/src/services/cadastur.ts
+++ b/api/src/services/cadastur.ts
@@ -1,22 +1,636 @@
-export interface CadasturGuide {
-  id: string;
-  name: string;
-  registryNumber: string;
-  expiresAt: Date;
-}
+export type CadasturMappedField =
+  | 'cadasturNumber'
+  | 'name'
+  | 'email'
+  | 'languages'
+  | 'serviceAreas'
+  | 'status'
+  | 'certificateValidity'
+  | 'municipality'
+  | 'uf'
+  | 'phone'
+  | 'website'
+  | 'activity'
+  | 'categories'
+  | 'segments'
+  | 'isDriver';
 
-export class CadasturService {
-  constructor(private readonly baseUrl: string, private readonly apiKey?: string) {}
+export type CadasturFieldMapping = Record<string, CadasturMappedField | null>;
 
-  async fetchGuide(registryNumber: string): Promise<CadasturGuide | null> {
-    void this.apiKey;
-    void this.baseUrl;
+export type CadasturNormalizedRecord = {
+  cadasturNumber: string | null;
+  name: string | null;
+  email: string | null;
+  languages: string[];
+  serviceAreas: string[];
+  status: string | null;
+  statusOriginal: string | null;
+  certificateValidity: string | null;
+  certificateValidityOriginal: string | null;
+  municipality: string | null;
+  uf: string | null;
+  phone: string | null;
+  website: string | null;
+  activity: string | null;
+  categories: string[];
+  segments: string[];
+  isDriver: boolean | null;
+};
 
-    return {
-      id: registryNumber,
-      name: 'Placeholder Guide',
-      registryNumber,
-      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
-    };
+export type CadasturCsvRow = {
+  rowNumber: number;
+  raw: Record<string, string>;
+  normalized: CadasturNormalizedRecord;
+};
+
+export type CadasturCsvParseResult = {
+  rows: CadasturCsvRow[];
+  fieldMapping: CadasturFieldMapping;
+  delimiter: string;
+};
+
+export type CadasturImportStatusEvaluation = 'ACTIVE' | 'INACTIVE' | 'UNKNOWN';
+
+export class CadasturCsvError extends Error {}
+
+const CANDIDATE_DELIMITERS = [',', ';', '\t', '|'] as const;
+
+const HEADER_FIELD_MAP = new Map<string, CadasturMappedField>([
+  ['cadastur', 'cadasturNumber'],
+  ['cadasturnumber', 'cadasturNumber'],
+  ['numerodocadastur', 'cadasturNumber'],
+  ['numerodocertificado', 'cadasturNumber'],
+  ['numeroderegistro', 'cadasturNumber'],
+  ['registro', 'cadasturNumber'],
+  ['nregistrotur', 'cadasturNumber'],
+  ['ncadastur', 'cadasturNumber'],
+  ['name', 'name'],
+  ['nome', 'name'],
+  ['nomecompleto', 'name'],
+  ['nomedoguia', 'name'],
+  ['guidename', 'name'],
+  ['responsavel', 'name'],
+  ['email', 'email'],
+  ['emailcomercial', 'email'],
+  ['emailprincipal', 'email'],
+  ['contatoemail', 'email'],
+  ['idiomas', 'languages'],
+  ['idioma', 'languages'],
+  ['idiomasdeatuacao', 'languages'],
+  ['idiomasatendidos', 'languages'],
+  ['linguas', 'languages'],
+  ['linguagens', 'languages'],
+  ['municipiodeatuacao', 'serviceAreas'],
+  ['municipiosdeatuacao', 'serviceAreas'],
+  ['areasdeatuacao', 'serviceAreas'],
+  ['atuacao', 'serviceAreas'],
+  ['cidadesatendidas', 'serviceAreas'],
+  ['municipio', 'municipality'],
+  ['municipiodeorigem', 'municipality'],
+  ['cidade', 'municipality'],
+  ['uf', 'uf'],
+  ['estado', 'uf'],
+  ['estados', 'uf'],
+  ['validade', 'certificateValidity'],
+  ['validadedocertificado', 'certificateValidity'],
+  ['datavalidade', 'certificateValidity'],
+  ['datadevalidade', 'certificateValidity'],
+  ['dataexpiracao', 'certificateValidity'],
+  ['status', 'status'],
+  ['situacao', 'status'],
+  ['situacaodocadastro', 'status'],
+  ['situacaocadastur', 'status'],
+  ['situacaocertificado', 'status'],
+  ['atividade', 'activity'],
+  ['atividadeturistica', 'activity'],
+  ['atividadeprincipal', 'activity'],
+  ['categorias', 'categories'],
+  ['categoria', 'categories'],
+  ['segmentos', 'segments'],
+  ['segmento', 'segments'],
+  ['guiamotorista', 'isDriver'],
+  ['motoristaguia', 'isDriver'],
+  ['guiamotorista?', 'isDriver'],
+  ['telefone', 'phone'],
+  ['telefonecomercial', 'phone'],
+  ['contatotelefone', 'phone'],
+  ['telefone1', 'phone'],
+  ['website', 'website'],
+  ['site', 'website'],
+  ['paginaweb', 'website'],
+]);
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+
+const ACTIVE_STATUS_CODES = new Set([
+  'ATIVO',
+  'ATIVA',
+  'REGULAR',
+  'EMDIA',
+  'EM DIA',
+  'VALIDO',
+  'HABILITADO',
+]);
+
+const INACTIVE_STATUS_KEYWORDS = [
+  'INATIV',
+  'CANCEL',
+  'SUSP',
+  'VENC',
+  'EXPIR',
+  'IRREG',
+  'BAIXA',
+  'ENCERR',
+  'DESATIV',
+  'PENDENTE',
+];
+
+const normalizeHeaderKey = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+
+const detectDelimiter = (headerLine: string): string => {
+  let bestDelimiter = ',';
+  let bestCount = -1;
+
+  for (const delimiter of CANDIDATE_DELIMITERS) {
+    const count = headerLine.split(delimiter).length - 1;
+    if (count > bestCount) {
+      bestCount = count;
+      bestDelimiter = delimiter;
+    }
   }
-}
+
+  if (bestCount <= 0) {
+    if (headerLine.includes(';')) {
+      return ';';
+    }
+
+    if (headerLine.includes('\t')) {
+      return '\t';
+    }
+
+    if (headerLine.includes('|')) {
+      return '|';
+    }
+
+    return ',';
+  }
+
+  return bestDelimiter;
+};
+
+const parseCsvContent = (content: string, delimiter: string): string[][] => {
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentValue = '';
+  let inQuotes = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+
+    if (char === '"') {
+      if (inQuotes && content[index + 1] === '"') {
+        currentValue += '"';
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === '\r') {
+      if (inQuotes) {
+        currentValue += char;
+      }
+      continue;
+    }
+
+    if (char === '\n') {
+      if (inQuotes) {
+        currentValue += char;
+      } else {
+        currentRow.push(currentValue);
+        currentValue = '';
+        rows.push(currentRow);
+        currentRow = [];
+      }
+      continue;
+    }
+
+    if (char === delimiter && !inQuotes) {
+      currentRow.push(currentValue);
+      currentValue = '';
+      continue;
+    }
+
+    currentValue += char;
+  }
+
+  if (inQuotes) {
+    throw new CadasturCsvError('CSV possui aspas não balanceadas');
+  }
+
+  if (currentValue.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentValue);
+  }
+
+  if (currentRow.length > 0) {
+    rows.push(currentRow);
+  }
+
+  return rows;
+};
+
+const toTitleCase = (value: string): string => {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return '';
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  return lower
+    .split(/\s+/)
+    .map((segment) => (segment.length === 0 ? '' : segment[0].toUpperCase() + segment.slice(1)))
+    .join(' ');
+};
+
+const uniqueList = (values: string[]): string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const key = value.trim().toLowerCase();
+    if (key.length === 0) {
+      continue;
+    }
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(value.trim());
+    }
+  }
+
+  return result;
+};
+
+const splitList = (value: string): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  const parts = value
+    .split(/[|;,]/)
+    .map((part) => toTitleCase(part))
+    .filter((part) => part.length > 0);
+
+  return uniqueList(parts);
+};
+
+const normalizeCadasturNumber = (value: string): string | null => {
+  const digits = value.replace(/\D/g, '');
+  if (digits.length < 5) {
+    return null;
+  }
+  return digits;
+};
+
+const normalizeEmail = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  if (!EMAIL_REGEX.test(lower)) {
+    return null;
+  }
+
+  return lower;
+};
+
+const normalizeStatus = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  return trimmed
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^A-Z\s]/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toUpperCase();
+};
+
+export const evaluateCadasturStatus = (
+  status: string | null,
+): CadasturImportStatusEvaluation => {
+  if (!status) {
+    return 'UNKNOWN';
+  }
+
+  const compact = status.replace(/\s+/g, '');
+
+  if (ACTIVE_STATUS_CODES.has(compact)) {
+    return 'ACTIVE';
+  }
+
+  for (const keyword of INACTIVE_STATUS_KEYWORDS) {
+    if (compact.includes(keyword)) {
+      return 'INACTIVE';
+    }
+  }
+
+  return 'UNKNOWN';
+};
+
+const parseDateValue = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const normalized = trimmed.replace(/\s+/g, ' ');
+
+  const matchBR = normalized.match(/^(\d{1,2})[\/-](\d{1,2})[\/-](\d{2,4})$/);
+  if (matchBR) {
+    const day = Number.parseInt(matchBR[1], 10);
+    const month = Number.parseInt(matchBR[2], 10);
+    let year = Number.parseInt(matchBR[3], 10);
+
+    if (year < 100) {
+      year += year >= 70 ? 1900 : 2000;
+    }
+
+    if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
+      return new Date(Date.UTC(year, month - 1, day)).toISOString();
+    }
+  }
+
+  const matchISO = normalized.match(/^(\d{4})[\/-](\d{1,2})[\/-](\d{1,2})$/);
+  if (matchISO) {
+    const year = Number.parseInt(matchISO[1], 10);
+    const month = Number.parseInt(matchISO[2], 10);
+    const day = Number.parseInt(matchISO[3], 10);
+
+    if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
+      return new Date(Date.UTC(year, month - 1, day)).toISOString();
+    }
+  }
+
+  const parsed = new Date(normalized);
+  if (!Number.isNaN(parsed.getTime())) {
+    return new Date(
+      Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate()),
+    ).toISOString();
+  }
+
+  return null;
+};
+
+const normalizePhone = (value: string): string | null => {
+  const digits = value.replace(/\D/g, '');
+  if (digits.length < 8) {
+    return null;
+  }
+  return digits;
+};
+
+const normalizeWebsite = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  return trimmed;
+};
+
+const parseBooleanValue = (value: string): boolean | null => {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const normalized = trimmed
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase();
+
+  if (['1', 'true', 'sim', 's', 'yes'].includes(normalized)) {
+    return true;
+  }
+
+  if (['0', 'false', 'nao', 'n', 'no'].includes(normalized)) {
+    return false;
+  }
+
+  return null;
+};
+
+export const parseCadasturCsv = (input: Buffer | string): CadasturCsvParseResult => {
+  let content = typeof input === 'string' ? input : input.toString('utf-8');
+
+  if (content.length === 0) {
+    throw new CadasturCsvError('Arquivo CSV vazio');
+  }
+
+  if (content.charCodeAt(0) === 0xfeff) {
+    content = content.slice(1);
+  }
+
+  const lines = content.split(/\r?\n/);
+  const firstLine = lines.find((line) => line.trim().length > 0);
+
+  if (!firstLine) {
+    throw new CadasturCsvError('Arquivo CSV sem dados');
+  }
+
+  const delimiter = detectDelimiter(firstLine);
+  const table = parseCsvContent(content, delimiter);
+
+  if (table.length === 0) {
+    throw new CadasturCsvError('Arquivo CSV sem dados');
+  }
+
+  const headerRow = table[0].map((header) => header.trim());
+
+  if (headerRow.length === 0) {
+    throw new CadasturCsvError('Cabeçalho do CSV ausente');
+  }
+
+  const fieldMapping: CadasturFieldMapping = {};
+
+  for (const header of headerRow) {
+    const normalized = normalizeHeaderKey(header);
+    const mapped = HEADER_FIELD_MAP.get(normalized) ?? null;
+    fieldMapping[header] = mapped;
+  }
+
+  const rows: CadasturCsvRow[] = [];
+
+  for (let index = 1; index < table.length; index += 1) {
+    const row = table[index];
+
+    if (row.length === 1 && row[0].trim().length === 0) {
+      continue;
+    }
+
+    if (row.length !== headerRow.length) {
+      throw new CadasturCsvError(
+        `Linha ${index + 1} possui ${row.length} colunas, esperado ${headerRow.length}`,
+      );
+    }
+
+    const raw: Record<string, string> = {};
+    const normalized: CadasturNormalizedRecord = {
+      cadasturNumber: null,
+      name: null,
+      email: null,
+      languages: [],
+      serviceAreas: [],
+      status: null,
+      statusOriginal: null,
+      certificateValidity: null,
+      certificateValidityOriginal: null,
+      municipality: null,
+      uf: null,
+      phone: null,
+      website: null,
+      activity: null,
+      categories: [],
+      segments: [],
+      isDriver: null,
+    };
+
+    for (let col = 0; col < headerRow.length; col += 1) {
+      const header = headerRow[col];
+      const value = row[col] ?? '';
+      const trimmedValue = value.trim();
+
+      raw[header] = trimmedValue;
+
+      const mappedField = fieldMapping[header];
+      if (!mappedField) {
+        continue;
+      }
+
+      switch (mappedField) {
+        case 'cadasturNumber': {
+          if (trimmedValue.length > 0) {
+            normalized.cadasturNumber = normalizeCadasturNumber(trimmedValue);
+          }
+          break;
+        }
+        case 'name': {
+          if (trimmedValue.length > 0) {
+            const title = toTitleCase(trimmedValue);
+            normalized.name = title.length > 0 ? title : trimmedValue;
+          }
+          break;
+        }
+        case 'email': {
+          if (trimmedValue.length > 0) {
+            normalized.email = normalizeEmail(trimmedValue);
+          }
+          break;
+        }
+        case 'languages': {
+          normalized.languages = normalized.languages.concat(splitList(trimmedValue));
+          break;
+        }
+        case 'serviceAreas': {
+          normalized.serviceAreas = normalized.serviceAreas.concat(splitList(trimmedValue));
+          break;
+        }
+        case 'status': {
+          normalized.statusOriginal = trimmedValue.length > 0 ? trimmedValue : null;
+          normalized.status = trimmedValue.length > 0 ? normalizeStatus(trimmedValue) : null;
+          break;
+        }
+        case 'certificateValidity': {
+          normalized.certificateValidityOriginal =
+            trimmedValue.length > 0 ? trimmedValue : null;
+          normalized.certificateValidity =
+            trimmedValue.length > 0 ? parseDateValue(trimmedValue) : null;
+          break;
+        }
+        case 'municipality': {
+          if (trimmedValue.length > 0) {
+            const title = toTitleCase(trimmedValue);
+            normalized.municipality = title.length > 0 ? title : trimmedValue;
+          }
+          break;
+        }
+        case 'uf': {
+          if (trimmedValue.length > 0) {
+            normalized.uf = trimmedValue.replace(/[^a-zA-Z]/g, '').toUpperCase().slice(0, 3);
+          }
+          break;
+        }
+        case 'phone': {
+          if (trimmedValue.length > 0) {
+            normalized.phone = normalizePhone(trimmedValue);
+          }
+          break;
+        }
+        case 'website': {
+          if (trimmedValue.length > 0) {
+            normalized.website = normalizeWebsite(trimmedValue);
+          }
+          break;
+        }
+        case 'activity': {
+          if (trimmedValue.length > 0) {
+            const title = toTitleCase(trimmedValue);
+            normalized.activity = title.length > 0 ? title : trimmedValue;
+          }
+          break;
+        }
+        case 'categories': {
+          normalized.categories = normalized.categories.concat(splitList(trimmedValue));
+          break;
+        }
+        case 'segments': {
+          normalized.segments = normalized.segments.concat(splitList(trimmedValue));
+          break;
+        }
+        case 'isDriver': {
+          if (trimmedValue.length > 0) {
+            normalized.isDriver = parseBooleanValue(trimmedValue);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    normalized.languages = uniqueList(normalized.languages);
+    normalized.serviceAreas = uniqueList(normalized.serviceAreas);
+    normalized.categories = uniqueList(normalized.categories);
+    normalized.segments = uniqueList(normalized.segments);
+
+    rows.push({
+      rowNumber: index + 1,
+      raw,
+      normalized,
+    });
+  }
+
+  return {
+    rows,
+    fieldMapping,
+    delimiter,
+  };
+};
+
+export const cadasturCsvService = {
+  parse: parseCadasturCsv,
+  evaluateStatus: evaluateCadasturStatus,
+};


### PR DESCRIPTION
## Summary
- add a dedicated Cadastur CSV parser/normalizer service
- expose preview and import workflows for Cadastur data in the admin guide service and routes
- remove the deprecated Cadastur import endpoint from the admin root router

## Testing
- `npm run build` *(fails: existing Prisma client types are not available, affects dashboard/expedition/reservation/review modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9a6247388324a20acd5fcab6e8b5