### PR TITLE
Handle missing package-lock files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,23 @@ jobs:
             api/package-lock.json
 
       - name: Install root dependencies
-        run: npm ci
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            echo "package-lock.json not found. Falling back to 'npm install'."
+            npm install
+          fi
 
       - name: Install API dependencies
         working-directory: api
-        run: npm ci
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            echo "package-lock.json not found in ./api. Falling back to 'npm install'."
+            npm install
+          fi
 
       - name: Prisma generate
         working-directory: api


### PR DESCRIPTION
## Summary
- fallback to `npm install` when the root lockfile is missing so `npm ci` does not abort
- apply the same fallback when installing API dependencies

## Testing
- Not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cddf54ced883249db416408c0eccd9