### PR TITLE
Handle missing npm lockfiles more robustly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,20 +38,38 @@ jobs:
 
       - name: Install root dependencies
         run: |
-          if [ -f package-lock.json ]; then
+          if [ ! -s package-lock.json ]; then
+            echo "package-lock.json not found or empty. Attempting to generate lockfile with 'npm install --package-lock-only'."
+            if npm install --package-lock-only; then
+              echo "Generated package-lock.json using 'npm install --package-lock-only'."
+            else
+              echo "'npm install --package-lock-only' failed. Will fall back to a full 'npm install' if no lockfile is available."
+            fi
+          fi
+
+          if [ -s package-lock.json ]; then
             npm ci
           else
-            echo "package-lock.json not found. Falling back to 'npm install'."
+            echo "package-lock.json is still missing after attempting generation. Running 'npm install' instead of 'npm ci'."
             npm install
           fi
 
       - name: Install API dependencies
         working-directory: api
         run: |
-          if [ -f package-lock.json ]; then
+          if [ ! -s package-lock.json ]; then
+            echo "package-lock.json not found or empty in ./api. Attempting to generate lockfile with 'npm install --package-lock-only'."
+            if npm install --package-lock-only; then
+              echo "Generated package-lock.json for ./api using 'npm install --package-lock-only'."
+            else
+              echo "'npm install --package-lock-only' failed in ./api. Will fall back to a full 'npm install' if no lockfile is available."
+            fi
+          fi
+
+          if [ -s package-lock.json ]; then
             npm ci
           else
-            echo "package-lock.json not found in ./api. Falling back to 'npm install'."
+            echo "package-lock.json is still missing in ./api after attempting generation. Running 'npm install' instead of 'npm ci'."
             npm install
           fi
 


### PR DESCRIPTION
## Summary
- attempt to generate missing lockfiles in CI before installing dependencies and document whether generation succeeded
- fall back to npm install when a lockfile is still unavailable so npm ci no longer fails with EUSAGE

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cde28ce31483249ac962658378bf01